### PR TITLE
security: bump mkdocs-material minimum to fix XSS vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ dev = [
 ]
 docs = [
     "mkdocs>=1.6.0",
-    "mkdocs-material>=9.5.0",
+    "mkdocs-material>=9.6.19",
 ]
 
 [tool.ty.environment]


### PR DESCRIPTION
## Summary

- Bump mkdocs-material minimum version from 9.5.0 to 9.6.19
- Fixes XSS vulnerability in deep links within search results (SNYK-PYTHON-MKDOCSMATERIAL-7856160)
- Version 9.6.19 also adds Python 3.14 support, aligning with our test matrix

## References

- [Snyk Advisory: SNYK-PYTHON-MKDOCSMATERIAL-7856160](https://security.snyk.io/vuln/SNYK-PYTHON-MKDOCSMATERIAL-7856160)
- [mkdocs-material 9.5.32 Release Notes](https://github.com/squidfunk/mkdocs-material/releases/tag/9.5.32) (security fix)
- [mkdocs-material 9.6.19 Release Notes](https://github.com/squidfunk/mkdocs-material/releases/tag/9.6.19) (Python 3.14 support)

## Test plan

- [ ] Docs workflow builds successfully with new minimum version