### PR TITLE
feat!: multi-UUID version support (1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-02-27
 
 ### Added
 
@@ -141,7 +141,8 @@ mock_uuid.uuid4.call_count
 - Module ignore configuration via `pyproject.toml` or `pytest.ini`
 - Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14 support
 
-[Unreleased]: https://github.com/CaptainDriftwood/pytest-uuid/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/CaptainDriftwood/pytest-uuid/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/CaptainDriftwood/pytest-uuid/compare/v0.6.0...v1.0.0
 [0.6.0]: https://github.com/CaptainDriftwood/pytest-uuid/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/CaptainDriftwood/pytest-uuid/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/CaptainDriftwood/pytest-uuid/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Thread-safe call tracking: `call_count`, `calls`, `generated_uuids`, and related properties now use per-instance locks for safe concurrent access from multiple threads
+
 ### Changed
 
 - Replaced import hook with permanent proxy approach for UUID mocking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Multi-UUID version support: mock uuid1, uuid4, uuid6, uuid7, uuid8; spy-only tracking for uuid3 and uuid5
+- Version-specific freeze functions: `freeze_uuid4`, `freeze_uuid1`, `freeze_uuid6`, `freeze_uuid7`, `freeze_uuid8`
+- Version-specific pytest markers: `@pytest.mark.freeze_uuid4`, `@pytest.mark.freeze_uuid1`, etc.
+- `UUIDMocker` container class with sub-mockers for each UUID version (`mock_uuid.uuid4`, `mock_uuid.uuid1`, etc.)
+- `NamespaceUUIDSpy` for tracking uuid3/uuid5 calls without mocking (deterministic hash-based UUIDs)
+- `node` and `clock_seq` parameters for uuid1/uuid6 to control time-based UUID components
 - Thread-safe call tracking: `call_count`, `calls`, `generated_uuids`, and related properties now use per-instance locks for safe concurrent access from multiple threads
+- `NamespaceUUIDCall` dataclass for uuid3/uuid5 call tracking with `namespace` and `name` fields
+- `uuid_version` field on `UUIDCall` dataclass to identify which UUID version was called
 
 ### Changed
 
+- **BREAKING**: `mock_uuid` fixture now requires explicit version access via properties (e.g., `mock_uuid.uuid4.set(...)` instead of `mock_uuid.set(...)`)
+- **BREAKING**: `freeze_uuid()` is now a deprecated alias for `freeze_uuid4()`; use version-specific functions instead
 - Replaced import hook with permanent proxy approach for UUID mocking
 - Simplified architecture: proxy installs once at plugin load, no per-import patching
 - Improved thread safety with lock-protected generator stack
@@ -26,6 +36,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `_import_hook.py` module (internal, replaced by `_proxy.py`)
+
+### Migration Guide
+
+**mock_uuid fixture changes:**
+```python
+# Before (0.6.x)
+mock_uuid.set("12345678-1234-4678-8234-567812345678")
+mock_uuid.call_count
+
+# After (0.7.0+)
+mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+mock_uuid.uuid4.call_count
+```
+
+**freeze_uuid decorator changes:**
+```python
+# Before (0.6.x)
+@freeze_uuid("12345678-1234-4678-8234-567812345678")
+
+# After (0.7.0+) - use version-specific function
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
+```
 
 ## [0.6.0] - 2026-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 mock_uuid.set("12345678-1234-4678-8234-567812345678")
 mock_uuid.call_count
 
-# After (0.7.0+)
+# After (1.0.0+)
 mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 mock_uuid.uuid4.call_count
 ```
@@ -55,7 +55,7 @@ mock_uuid.uuid4.call_count
 # Before (0.6.x)
 @freeze_uuid("12345678-1234-4678-8234-567812345678")
 
-# After (0.7.0+) - use version-specific function
+# After (1.0.0+) - use version-specific function
 @freeze_uuid4("12345678-1234-4678-8234-567812345678")
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ def test_static(mock_uuid):
     assert uuid.uuid4() == uuid.uuid4()  # Same UUID
 
 # Or with decorator
-@freeze_uuid("12345678-1234-4678-8234-567812345678")
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
 def test_static_decorator():
     assert uuid.uuid4() == uuid.uuid4()  # Same UUID
 ```
@@ -173,7 +173,7 @@ def test_seeded(mock_uuid):
     assert uuid.uuid4() == first  # Same UUID
 
 # With decorator
-@freeze_uuid(seed=42)
+@freeze_uuid4(seed=42)
 def test_seeded_decorator():
     result = uuid.uuid4()
     assert result.version == 4  # Valid UUID v4
@@ -189,7 +189,7 @@ def test_node_seeded(mock_uuid):
     # Same test always produces the same sequence
 
 # With marker
-@pytest.mark.freeze_uuid(seed="node")
+@pytest.mark.freeze_uuid4(seed="node")
 def test_node_seeded_marker():
     # Same test always produces the same sequence
     pass
@@ -204,7 +204,7 @@ import uuid
 import pytest
 
 
-@pytest.mark.freeze_uuid(seed="node")
+@pytest.mark.freeze_uuid4(seed="node")
 class TestUserService:
     def test_create(self):
         # Seed derived from "test_module.py::TestUserService::test_create"
@@ -224,7 +224,7 @@ class TestUserService:
 import uuid
 import pytest
 
-pytestmark = pytest.mark.freeze_uuid(seed="node")
+pytestmark = pytest.mark.freeze_uuid4(seed="node")
 
 
 def test_create_user():
@@ -320,7 +320,7 @@ def test_exhaustion_raise(mock_uuid):
         uuid.uuid4()  # Raises - sequence exhausted
 
 # With decorator
-@freeze_uuid(
+@freeze_uuid4(
     ["11111111-1111-4111-8111-111111111111"],
     on_exhausted="raise",  # or "cycle" or "random"
 )
@@ -485,11 +485,11 @@ def test_with_ignored_modules(mock_uuid):
 #### Decorator/Marker API
 
 ```python
-@freeze_uuid("12345678-1234-4678-8234-567812345678", ignore=["sqlalchemy"])
+@freeze_uuid4("12345678-1234-4678-8234-567812345678", ignore=["sqlalchemy"])
 def test_with_decorator():
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 
-@pytest.mark.freeze_uuid("...", ignore=["celery"])
+@pytest.mark.freeze_uuid4("...", ignore=["celery"])
 def test_with_marker():
     pass
 ```
@@ -599,7 +599,7 @@ Apply to all tests in a module using pytest's `pytestmark`:
 import uuid
 import pytest
 
-pytestmark = pytest.mark.freeze_uuid("12345678-1234-4678-8234-567812345678")
+pytestmark = pytest.mark.freeze_uuid4("12345678-1234-4678-8234-567812345678")
 
 
 def test_create_user():
@@ -616,10 +616,10 @@ Apply the decorator to a test class to freeze UUIDs for all test methods:
 
 ```python
 import uuid
-from pytest_uuid import freeze_uuid
+from pytest_uuid import freeze_uuid4
 
 
-@freeze_uuid("12345678-1234-4678-8234-567812345678")
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
 class TestUserService:
     def test_create(self):
         assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
@@ -635,7 +635,7 @@ import uuid
 import pytest
 
 
-@pytest.mark.freeze_uuid(seed=42)
+@pytest.mark.freeze_uuid4(seed=42)
 class TestSeededService:
     def test_one(self):
         result = uuid.uuid4()

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ uv add pytest-uuid
 import uuid
 
 def test_single_uuid(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 
 def test_multiple_uuids(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )
@@ -114,7 +114,7 @@ Return the same UUID every time:
 
 ```python
 def test_static(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert uuid.uuid4() == uuid.uuid4()  # Same UUID
 
 # Or with decorator
@@ -129,7 +129,7 @@ Return UUIDs from a list:
 
 ```python
 def test_sequence(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )
@@ -145,10 +145,10 @@ Generate reproducible UUIDs from a seed:
 
 ```python
 def test_seeded(mock_uuid):
-    mock_uuid.set_seed(42)
+    mock_uuid.uuid4.set_seed(42)
     first = uuid.uuid4()
 
-    mock_uuid.set_seed(42)  # Reset to same seed
+    mock_uuid.uuid4.set_seed(42)  # Reset to same seed
     assert uuid.uuid4() == first  # Same UUID
 
 # With decorator
@@ -164,7 +164,7 @@ Derive the seed from the test's node ID for automatic reproducibility:
 
 ```python
 def test_node_seeded(mock_uuid):
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     # Same test always produces the same sequence
 
 # With marker
@@ -255,8 +255,8 @@ Control what happens when a UUID sequence is exhausted:
 from pytest_uuid import ExhaustionBehavior, UUIDsExhaustedError
 
 def test_exhaustion_raise(mock_uuid):
-    mock_uuid.set_exhaustion_behavior("raise")
-    mock_uuid.set("11111111-1111-4111-8111-111111111111")
+    mock_uuid.uuid4.set_exhaustion_behavior("raise")
+    mock_uuid.uuid4.set("11111111-1111-4111-8111-111111111111")
 
     uuid.uuid4()  # Returns the UUID
 
@@ -303,26 +303,26 @@ def test_user_generates_uuid(spy_uuid):
     assert user.id == str(spy_uuid.last_uuid)
 ```
 
-#### Using `mock_uuid.spy()`
+#### Using `mock_uuid.uuid4.spy()`
 
 Switch from mocked to real UUIDs mid-test:
 
 ```python
 def test_start_mocked_then_spy(mock_uuid):
     """Start with mocked UUIDs, then switch to real ones."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     first = uuid.uuid4()  # Mocked
 
-    mock_uuid.spy()  # Switch to spy mode
+    mock_uuid.uuid4.spy()  # Switch to spy mode
     second = uuid.uuid4()  # Real random UUID
 
     assert str(first) == "12345678-1234-4678-8234-567812345678"
     assert first != second  # second is random
-    assert mock_uuid.mocked_count == 1
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.mocked_count == 1
+    assert mock_uuid.uuid4.real_count == 1
 ```
 
-> **When to use which:** Use `spy_uuid` when you never need mocking in the test. Use `mock_uuid.spy()` when you need to switch between mocked and real UUIDs within the same test.
+> **When to use which:** Use `spy_uuid` when you never need mocking in the test. Use `mock_uuid.uuid4.spy()` when you need to switch between mocked and real UUIDs within the same test.
 
 ### Additional UUID Versions
 
@@ -392,7 +392,7 @@ def test_uuid7_seeded(mock_uuid):
 
 def test_all_versions_independent(mock_uuid):
     """Each UUID version is mocked independently."""
-    mock_uuid.set("44444444-4444-4444-8444-444444444444")  # uuid4
+    mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")  # uuid4
     mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
     mock_uuid.uuid7.set("77777777-7777-7777-8777-777777777777")
 
@@ -401,7 +401,7 @@ def test_all_versions_independent(mock_uuid):
     assert str(uuid7()) == "77777777-7777-7777-8777-777777777777"
 
     # Call counts are tracked independently
-    assert mock_uuid.call_count == 1      # uuid4
+    assert mock_uuid.uuid4.call_count == 1      # uuid4
     assert mock_uuid.uuid1.call_count == 1
     assert mock_uuid.uuid7.call_count == 1
 ```
@@ -416,8 +416,8 @@ Exclude specific packages from UUID mocking so they receive real UUIDs. This is 
 
 ```python
 def test_with_ignored_modules(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("sqlalchemy", "celery")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("sqlalchemy", "celery")
 
     # Direct calls are mocked
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
@@ -444,14 +444,14 @@ def test_with_marker():
 
 ```python
 def test_tracking(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("mylib")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("mylib")
 
     uuid.uuid4()           # mocked
     mylib.create_record()  # real (from ignored module)
 
-    assert mock_uuid.mocked_count == 1
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.mocked_count == 1
+    assert mock_uuid.uuid4.real_count == 1
 ```
 
 ### Global Configuration
@@ -495,7 +495,7 @@ def create_user():
 # tests/test_models.py
 def test_create_user(mock_uuid_factory):
     with mock_uuid_factory("myapp.models") as mocker:
-        mocker.set("12345678-1234-4678-8234-567812345678")
+        mocker.uuid4.set("12345678-1234-4678-8234-567812345678")
         user = create_user()
         assert user["id"] == "12345678-1234-4678-8234-567812345678"
 ```
@@ -612,9 +612,21 @@ def freeze_uuids_globally():
 
 #### `mock_uuid`
 
-Main fixture for controlling `uuid.uuid4()` calls.
+Container fixture providing access to mockers for all UUID versions.
 
-**Methods:**
+**Properties (version-specific mockers):**
+- `mock_uuid.uuid4` - UUID4Mocker for `uuid.uuid4()` (see methods below)
+- `mock_uuid.uuid1` - UUID1Mocker for `uuid.uuid1()` with `set()`, `set_seed()`, `set_node()`, `set_clock_seq()`
+- `mock_uuid.uuid3` - NamespaceUUIDSpy for `uuid.uuid3()` (spy-only, tracks namespace/name)
+- `mock_uuid.uuid5` - NamespaceUUIDSpy for `uuid.uuid5()` (spy-only, tracks namespace/name)
+- `mock_uuid.uuid6` - UUID6Mocker for `uuid.uuid6()` with `set()`, `set_seed()`, `set_node()` (requires uuid6 package)
+- `mock_uuid.uuid7` - UUID7Mocker for `uuid.uuid7()` with `set()`, `set_seed()` (requires uuid6 package)
+- `mock_uuid.uuid8` - UUID8Mocker for `uuid.uuid8()` with `set()`, `set_seed()` (requires uuid6 package)
+
+**Container Methods:**
+- `reset()` - Reset all initialized sub-mockers to initial state
+
+**UUID4Mocker Methods** (accessed via `mock_uuid.uuid4`):
 - `set(*uuids)` - Set one or more UUIDs to return (cycles by default)
 - `set_default(uuid)` - Set a default UUID for all calls
 - `set_seed(seed)` - Set a seed for reproducible generation
@@ -624,21 +636,13 @@ Main fixture for controlling `uuid.uuid4()` calls.
 - `reset()` - Reset to initial state
 - `set_ignore(*module_prefixes)` - Set modules to ignore (returns real UUIDs)
 
-**Sub-Mockers (accessed as properties):**
-- `mock_uuid.uuid1` - UUID1Mocker for `uuid.uuid1()` with `set()`, `set_seed()`, `set_node()`, `set_clock_seq()`
-- `mock_uuid.uuid3` - NamespaceUUIDSpy for `uuid.uuid3()` (spy-only, tracks namespace/name)
-- `mock_uuid.uuid5` - NamespaceUUIDSpy for `uuid.uuid5()` (spy-only, tracks namespace/name)
-- `mock_uuid.uuid6` - UUID6Mocker for `uuid.uuid6()` with `set()`, `set_seed()`, `set_node()` (requires uuid6 package)
-- `mock_uuid.uuid7` - UUID7Mocker for `uuid.uuid7()` with `set()`, `set_seed()` (requires uuid6 package)
-- `mock_uuid.uuid8` - UUID8Mocker for `uuid.uuid8()` with `set()`, `set_seed()` (requires uuid6 package)
-
 #### `mock_uuid_factory`
 
 Factory for module-specific mocking.
 
 ```python
 with mock_uuid_factory("module.path") as mocker:
-    mocker.set("...")
+    mocker.uuid4.set("...")
 ```
 
 #### `spy_uuid`
@@ -671,10 +675,10 @@ Both `mock_uuid` and `spy_uuid` fixtures provide detailed call tracking via the 
 from pytest_uuid.types import UUIDCall
 
 def test_call_tracking(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     uuid.uuid4()
 
-    call = mock_uuid.calls[0]
+    call = mock_uuid.uuid4.calls[0]
     assert call.uuid == uuid.UUID("12345678-1234-4678-8234-567812345678")
     assert call.was_mocked is True
     assert call.caller_module is not None
@@ -691,13 +695,13 @@ def test_call_tracking(mock_uuid):
 - `caller_function` - Function name where the call originated
 - `caller_qualname` - Qualified name (e.g., `MyClass.method` or `outer.<locals>.inner`)
 
-**Tracking Properties** (available on both `mock_uuid` and `spy_uuid`):
+**Tracking Properties** (available on `mock_uuid.uuid4` and `spy_uuid`):
 - `call_count` - Total number of uuid4 calls
 - `generated_uuids` - List of all UUIDs returned
 - `last_uuid` - Most recently returned UUID
 - `calls` - List of `UUIDCall` records with full metadata
 
-**Additional `mock_uuid` Properties:**
+**Additional `mock_uuid.uuid4` Properties:**
 - `mocked_calls` - Only calls that returned mocked UUIDs
 - `real_calls` - Only calls that returned real UUIDs (spy mode or ignored modules)
 - `mocked_count` - Number of mocked calls
@@ -708,7 +712,7 @@ def test_call_tracking(mock_uuid):
 ```python
 def test_interrogate_calls(mock_uuid):
     """Inspect detailed metadata for all uuid4 calls."""
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
     )
@@ -717,15 +721,15 @@ def test_interrogate_calls(mock_uuid):
     second = uuid.uuid4()
 
     # Check all UUIDs generated
-    assert len(mock_uuid.generated_uuids) == 2
-    assert mock_uuid.generated_uuids[0] == first
-    assert mock_uuid.generated_uuids[1] == second
+    assert len(mock_uuid.uuid4.generated_uuids) == 2
+    assert mock_uuid.uuid4.generated_uuids[0] == first
+    assert mock_uuid.uuid4.generated_uuids[1] == second
 
     # Get the last UUID quickly
-    assert mock_uuid.last_uuid == second
+    assert mock_uuid.uuid4.last_uuid == second
 
     # Iterate through call details
-    for i, call in enumerate(mock_uuid.calls):
+    for i, call in enumerate(mock_uuid.uuid4.calls):
         print(f"Call {i}: {call.uuid}")
         print(f"  Module: {call.caller_module}")
         print(f"  File: {call.caller_file}")
@@ -737,24 +741,24 @@ def test_interrogate_calls(mock_uuid):
 ```python
 def test_mixed_mocked_and_real(mock_uuid):
     """Track both mocked calls and real calls from ignored modules."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("mylib")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("mylib")
 
     uuid.uuid4()              # Mocked (direct call)
     mylib.create_record()     # Real (from ignored module)
     uuid.uuid4()              # Mocked (direct call)
 
     # Count by type
-    assert mock_uuid.call_count == 3
-    assert mock_uuid.mocked_count == 2
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.call_count == 3
+    assert mock_uuid.uuid4.mocked_count == 2
+    assert mock_uuid.uuid4.real_count == 1
 
     # Access only real calls
-    for call in mock_uuid.real_calls:
+    for call in mock_uuid.uuid4.real_calls:
         print(f"Real UUID from {call.caller_module}: {call.uuid}")
 
     # Access only mocked calls
-    for call in mock_uuid.mocked_calls:
+    for call in mock_uuid.uuid4.mocked_calls:
         assert call.was_mocked is True
 ```
 
@@ -762,14 +766,14 @@ def test_mixed_mocked_and_real(mock_uuid):
 
 ```python
 def test_filter_calls(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 
     uuid.uuid4()  # Call from test module
     mymodule.do_something()  # Calls uuid4 internally
 
     # Filter calls by module prefix
-    test_calls = mock_uuid.calls_from("tests")
-    module_calls = mock_uuid.calls_from("mymodule")
+    test_calls = mock_uuid.uuid4.calls_from("tests")
+    module_calls = mock_uuid.uuid4.calls_from("mymodule")
 
     # Useful for verifying specific modules made expected calls
     assert len(module_calls) == 1

--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ A pytest plugin for mocking UUID generation in your tests. Supports uuid1, uuid3
 ## Installation
 
 ```bash
-pip install pytest-uuid
+uv add --group dev pytest-uuid
+```
 
-# or with uv
-uv add pytest-uuid
+Or with pip:
+
+```bash
+pip install pytest-uuid
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -218,6 +218,41 @@ def test_create_admin():
     assert result.version == 4
 ```
 
+#### Function-Level Node Seeding (Autouse Fixture)
+
+For automatic node seeding on every test without markers:
+
+```python
+# conftest.py
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_seed_uuids(mock_uuid):
+    """Automatically seed uuid4 from test node ID for all tests."""
+    mock_uuid.uuid4.set_seed_from_node()
+```
+
+Every test now gets reproducible UUIDs without any boilerplate:
+
+```python
+# test_example.py
+import uuid
+
+
+def test_user_creation():
+    # No fixture argument needed - autouse handles it
+    # UUIDs are deterministic based on this test's node ID
+    user_id = uuid.uuid4()
+    assert user_id.version == 4
+
+
+def test_order_creation():
+    # Different test = different seed = different UUIDs
+    order_id = uuid.uuid4()
+    assert order_id.version == 4
+```
+
 #### Session-Level Node Seeding
 
 ```python

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,34 @@ Complete API documentation for pytest-uuid.
 
 ### mock_uuid
 
-Main fixture for controlling `uuid.uuid4()` calls.
+Container fixture providing access to mockers for all UUID versions.
+
+**Container Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `reset` | `reset()` | Reset all initialized sub-mockers |
+
+**Sub-Mockers (accessed as properties):**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `uuid4` | `UUID4Mocker` | Control `uuid.uuid4()` - random UUID |
+| `uuid1` | `UUID1Mocker` | Control `uuid.uuid1()` - time-based with MAC |
+| `uuid3` | `NamespaceUUIDSpy` | Track `uuid.uuid3()` - MD5 namespace hash |
+| `uuid5` | `NamespaceUUIDSpy` | Track `uuid.uuid5()` - SHA-1 namespace hash |
+| `uuid6` | `UUID6Mocker` | Control `uuid.uuid6()` - reordered time-based |
+| `uuid7` | `UUID7Mocker` | Control `uuid.uuid7()` - Unix timestamp-based |
+| `uuid8` | `UUID8Mocker` | Control `uuid.uuid8()` - experimental format |
+
+!!! note "uuid6/uuid7/uuid8 availability"
+    These require Python 3.14+ or the [uuid6](https://pypi.org/project/uuid6/) package on earlier versions.
+
+---
+
+### UUID4Mocker
+
+Mocker for `uuid.uuid4()` calls, accessed via `mock_uuid.uuid4`.
 
 **Methods:**
 
@@ -47,20 +74,6 @@ Main fixture for controlling `uuid.uuid4()` calls.
 |--------|-----------|-------------|
 | `calls_from` | `calls_from(module_prefix: str) -> list[UUIDCall]` | Filter calls by module |
 
-**Sub-Mockers (accessed as properties):**
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `uuid1` | `UUID1Mocker` | Control `uuid.uuid1()` - time-based with MAC |
-| `uuid3` | `NamespaceUUIDSpy` | Track `uuid.uuid3()` - MD5 namespace hash |
-| `uuid5` | `NamespaceUUIDSpy` | Track `uuid.uuid5()` - SHA-1 namespace hash |
-| `uuid6` | `UUID6Mocker` | Control `uuid.uuid6()` - reordered time-based |
-| `uuid7` | `UUID7Mocker` | Control `uuid.uuid7()` - Unix timestamp-based |
-| `uuid8` | `UUID8Mocker` | Control `uuid.uuid8()` - experimental format |
-
-!!! note "uuid6/uuid7/uuid8 availability"
-    These require Python 3.14+ or the [uuid6](https://pypi.org/project/uuid6/) package on earlier versions.
-
 ---
 
 ### mock_uuid_factory
@@ -72,7 +85,7 @@ Factory for module-specific mocking.
 ```python
 def test_example(mock_uuid_factory):
     with mock_uuid_factory("myapp.models") as mocker:
-        mocker.set("12345678-1234-4678-8234-567812345678")
+        mocker.uuid4.set("12345678-1234-4678-8234-567812345678")
         # Only myapp.models.uuid4 is mocked
 ```
 
@@ -238,7 +251,7 @@ Mocker for `uuid.uuid1()` calls, accessed via `mock_uuid.uuid1`.
 | `spy` | `spy()` | Enable spy mode |
 | `reset` | `reset()` | Reset to initial state |
 
-**Properties:** Same as `mock_uuid` (`call_count`, `calls`, `last_uuid`, etc.)
+**Properties:** Same as `UUID4Mocker` (`call_count`, `calls`, `last_uuid`, etc.)
 
 ---
 
@@ -282,7 +295,7 @@ Mockers for the newer RFC 9562 UUID versions, accessed via `mock_uuid.uuid6`, `m
 | `spy()` | All | Enable spy mode |
 | `reset()` | All | Reset to initial state |
 
-**Properties:** Same as `mock_uuid` (`call_count`, `calls`, `last_uuid`, etc.)
+**Properties:** Same as `UUID4Mocker` (`call_count`, `calls`, `last_uuid`, etc.)
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -47,6 +47,20 @@ Main fixture for controlling `uuid.uuid4()` calls.
 |--------|-----------|-------------|
 | `calls_from` | `calls_from(module_prefix: str) -> list[UUIDCall]` | Filter calls by module |
 
+**Sub-Mockers (accessed as properties):**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `uuid1` | `UUID1Mocker` | Control `uuid.uuid1()` - time-based with MAC |
+| `uuid3` | `NamespaceUUIDSpy` | Track `uuid.uuid3()` - MD5 namespace hash |
+| `uuid5` | `NamespaceUUIDSpy` | Track `uuid.uuid5()` - SHA-1 namespace hash |
+| `uuid6` | `UUID6Mocker` | Control `uuid.uuid6()` - reordered time-based |
+| `uuid7` | `UUID7Mocker` | Control `uuid.uuid7()` - Unix timestamp-based |
+| `uuid8` | `UUID8Mocker` | Control `uuid.uuid8()` - experimental format |
+
+!!! note "uuid6/uuid7/uuid8 availability"
+    These require Python 3.14+ or the [uuid6](https://pypi.org/project/uuid6/) package on earlier versions.
+
 ---
 
 ### mock_uuid_factory
@@ -181,6 +195,94 @@ from pytest_uuid.types import UUIDCall
 | `caller_line` | `int \| None` | Line number of the call |
 | `caller_function` | `str \| None` | Function name where the call originated |
 | `caller_qualname` | `str \| None` | Qualified name (e.g., `MyClass.method`) |
+| `uuid_version` | `int` | UUID version (1, 3, 4, 5, 6, 7, or 8) |
+
+---
+
+### NamespaceUUIDCall
+
+Dataclass for uuid3/uuid5 calls with namespace information.
+
+```python
+from pytest_uuid.types import NamespaceUUIDCall
+```
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `uuid` | `UUID` | The returned UUID |
+| `uuid_version` | `int` | UUID version (3 or 5) |
+| `namespace` | `UUID` | The namespace UUID used |
+| `name` | `str` | The name string used |
+| `caller_module` | `str \| None` | Module that made the call |
+| `caller_file` | `str \| None` | File path of the call |
+| `caller_line` | `int \| None` | Line number of the call |
+| `caller_function` | `str \| None` | Function name |
+| `caller_qualname` | `str \| None` | Qualified name |
+
+---
+
+### UUID1Mocker
+
+Mocker for `uuid.uuid1()` calls, accessed via `mock_uuid.uuid1`.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `set` | `set(*uuids: str \| UUID)` | Set UUID(s) to return |
+| `set_seed` | `set_seed(seed: int)` | Set seed for reproducible generation |
+| `set_node` | `set_node(node: int)` | Set fixed MAC address for real uuid1 |
+| `set_clock_seq` | `set_clock_seq(seq: int)` | Set fixed clock sequence |
+| `spy` | `spy()` | Enable spy mode |
+| `reset` | `reset()` | Reset to initial state |
+
+**Properties:** Same as `mock_uuid` (`call_count`, `calls`, `last_uuid`, etc.)
+
+---
+
+### NamespaceUUIDSpy
+
+Spy for `uuid.uuid3()` and `uuid.uuid5()` calls, accessed via `mock_uuid.uuid3` and `mock_uuid.uuid5`.
+
+!!! info "Spy-only mode"
+    uuid3 and uuid5 are deterministic (same inputs = same output), so they only support tracking, not mocking.
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `calls_with_namespace` | `calls_with_namespace(ns: UUID) -> list[NamespaceUUIDCall]` | Filter by namespace |
+| `calls_with_name` | `calls_with_name(name: str) -> list[NamespaceUUIDCall]` | Filter by name |
+| `reset` | `reset()` | Reset tracking |
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `call_count` | `int` | Number of calls |
+| `calls` | `list[NamespaceUUIDCall]` | All call records |
+| `last_uuid` | `UUID \| None` | Most recent UUID |
+
+---
+
+### UUID6Mocker, UUID7Mocker, UUID8Mocker
+
+Mockers for the newer RFC 9562 UUID versions, accessed via `mock_uuid.uuid6`, `mock_uuid.uuid7`, `mock_uuid.uuid8`.
+
+**Methods:**
+
+| Method | Available On | Description |
+|--------|--------------|-------------|
+| `set(*uuids)` | All | Set UUID(s) to return |
+| `set_seed(seed)` | All | Set seed for reproducible generation |
+| `set_node(node)` | uuid6 only | Set fixed node (MAC address) |
+| `set_clock_seq(seq)` | uuid6 only | Set fixed clock sequence |
+| `spy()` | All | Enable spy mode |
+| `reset()` | All | Reset to initial state |
+
+**Properties:** Same as `mock_uuid` (`call_count`, `calls`, `last_uuid`, etc.)
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -10,7 +10,7 @@ The simplest way to use pytest-uuid is with the `mock_uuid` fixture:
 import uuid
 
 def test_single_uuid(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
 
@@ -20,7 +20,7 @@ Return different UUIDs for each call:
 
 ```python
 def test_multiple_uuids(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -75,8 +75,8 @@ The ignore check inspects the entire call stack:
 
 ```python
 def test_ignore_in_stack(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("sqlalchemy")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("sqlalchemy")
 
     # Your code calls SQLAlchemy, which calls uuid.uuid4()
     # SQLAlchemy gets a real UUID because it's in the call stack
@@ -108,7 +108,7 @@ import pytest
 from pytest_uuid import UUIDsExhaustedError
 
 def test_strict(mock_uuid):
-    mock_uuid.set("11111111-1111-4111-8111-111111111111")
+    mock_uuid.uuid4.set("11111111-1111-4111-8111-111111111111")
 
     uuid.uuid4()  # OK
 

--- a/docs/guide/decorator-api.md
+++ b/docs/guide/decorator-api.md
@@ -2,6 +2,51 @@
 
 The `@freeze_uuid` decorator provides a clean way to configure UUID mocking at the function or class level.
 
+## Version-Specific Decorators
+
+Use the version-specific decorators for clarity and to enable version-specific features:
+
+| Decorator | UUID Version | Extra Parameters |
+|-----------|--------------|------------------|
+| `@freeze_uuid4(...)` | uuid4 (recommended) | - |
+| `@freeze_uuid1(...)` | uuid1 | `node`, `clock_seq` |
+| `@freeze_uuid6(...)` | uuid6 | `node`, `clock_seq` |
+| `@freeze_uuid7(...)` | uuid7 | - |
+| `@freeze_uuid8(...)` | uuid8 | - |
+| `@freeze_uuid(...)` | uuid4 (backward compatibility) | - |
+
+```python
+import uuid
+from pytest_uuid import freeze_uuid4, freeze_uuid1, freeze_uuid7
+
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
+def test_uuid4():
+    assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
+
+@freeze_uuid1(seed=42, node=0x123456789abc)
+def test_uuid1_with_node():
+    result = uuid.uuid1()
+    assert result.node == 0x123456789abc
+
+@freeze_uuid7(seed=42)
+def test_uuid7():
+    result = uuid.uuid7()
+    assert result.version == 7
+```
+
+### Stacking Multiple Versions
+
+Mock multiple UUID versions in the same test:
+
+```python
+@freeze_uuid4("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+@freeze_uuid1(seed=42)
+def test_multiple_versions():
+    assert str(uuid.uuid4()) == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    result1 = uuid.uuid1()
+    assert result1.version == 1
+```
+
 ## Basic Usage
 
 ```python
@@ -180,3 +225,5 @@ def test_inspect_seed():
 | `on_exhausted` | `str` | `"cycle"`, `"random"`, or `"raise"` |
 | `ignore` | `list[str]` | Module prefixes to exclude from mocking |
 | `ignore_defaults` | `bool` | Include default ignore list (default `True`) |
+| `node` | `int` | Fixed MAC address for uuid1/uuid6 |
+| `clock_seq` | `int` | Fixed clock sequence for uuid1/uuid6 |

--- a/docs/guide/fixture-api.md
+++ b/docs/guide/fixture-api.md
@@ -12,7 +12,7 @@ The main fixture for controlling `uuid.uuid4()` calls.
 import uuid
 
 def test_basic(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
 
@@ -22,7 +22,7 @@ Return the same UUID every time:
 
 ```python
 def test_static(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert uuid.uuid4() == uuid.uuid4()  # Same UUID
 ```
 
@@ -32,7 +32,7 @@ Return UUIDs from a list:
 
 ```python
 def test_sequence(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )
@@ -48,10 +48,10 @@ Generate reproducible UUIDs from a seed:
 
 ```python
 def test_seeded(mock_uuid):
-    mock_uuid.set_seed(42)
+    mock_uuid.uuid4.set_seed(42)
     first = uuid.uuid4()
 
-    mock_uuid.set_seed(42)  # Reset to same seed
+    mock_uuid.uuid4.set_seed(42)  # Reset to same seed
     assert uuid.uuid4() == first  # Same UUID
 ```
 
@@ -61,7 +61,7 @@ Derive the seed from the test's node ID:
 
 ```python
 def test_node_seeded(mock_uuid):
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     # Same test always produces the same sequence
 ```
 
@@ -71,13 +71,13 @@ Use the `seed` property to see the actual seed being used:
 
 ```python
 def test_inspect_seed(mock_uuid):
-    mock_uuid.set_seed(42)
-    assert mock_uuid.seed == 42
+    mock_uuid.uuid4.set_seed(42)
+    assert mock_uuid.uuid4.seed == 42
 
 def test_inspect_node_seed(mock_uuid):
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     # See the computed seed derived from the test's node ID
-    print(f"Using seed: {mock_uuid.seed}")  # e.g., 8427193654
+    print(f"Using seed: {mock_uuid.uuid4.seed}")  # e.g., 8427193654
 ```
 
 !!! tip "Debugging reproducibility"
@@ -94,8 +94,8 @@ import pytest
 from pytest_uuid import UUIDsExhaustedError
 
 def test_exhaustion_raise(mock_uuid):
-    mock_uuid.set_exhaustion_behavior("raise")
-    mock_uuid.set("11111111-1111-4111-8111-111111111111")
+    mock_uuid.uuid4.set_exhaustion_behavior("raise")
+    mock_uuid.uuid4.set("11111111-1111-4111-8111-111111111111")
 
     uuid.uuid4()  # Returns the UUID
 
@@ -115,8 +115,8 @@ Exclude specific packages from UUID mocking:
 
 ```python
 def test_with_ignored_modules(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("sqlalchemy", "celery")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("sqlalchemy", "celery")
 
     # Direct calls are mocked
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
@@ -133,10 +133,10 @@ Reset the fixture to its initial state:
 
 ```python
 def test_reset(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     uuid.uuid4()
 
-    mock_uuid.reset()
+    mock_uuid.uuid4.reset()
     # Back to initial state - no UUIDs configured
 ```
 
@@ -217,14 +217,14 @@ Each UUID version is tracked independently:
 
 ```python
 def test_all_versions_independent(mock_uuid):
-    mock_uuid.set("44444444-4444-4444-8444-444444444444")  # uuid4
+    mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")  # uuid4
     mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
 
     uuid.uuid4()
     uuid.uuid4()
     uuid.uuid1()
 
-    assert mock_uuid.call_count == 2      # uuid4 only
+    assert mock_uuid.uuid4.call_count == 2      # uuid4 only
     assert mock_uuid.uuid1.call_count == 1
 ```
 
@@ -244,7 +244,7 @@ def create_user():
 # tests/test_models.py
 def test_create_user(mock_uuid_factory):
     with mock_uuid_factory("myapp.models") as mocker:
-        mocker.set("12345678-1234-4678-8234-567812345678")
+        mocker.uuid4.set("12345678-1234-4678-8234-567812345678")
         user = create_user()
         assert user["id"] == "12345678-1234-4678-8234-567812345678"
 ```
@@ -256,11 +256,26 @@ By default, packages like `botocore` are ignored. Use `ignore_defaults=False` to
 ```python
 def test_mock_botocore(mock_uuid_factory):
     with mock_uuid_factory("botocore.handlers", ignore_defaults=False) as mocker:
-        mocker.set("12345678-1234-4678-8234-567812345678")
+        mocker.uuid4.set("12345678-1234-4678-8234-567812345678")
         # botocore will now receive mocked UUIDs
 ```
 
 ## Methods Reference
+
+### UUIDMocker (container)
+
+| Property/Method | Description |
+|-----------------|-------------|
+| `uuid4` | Access UUID4Mocker for `uuid.uuid4()` |
+| `uuid1` | Access UUID1Mocker for `uuid.uuid1()` |
+| `uuid3` | Access NamespaceUUIDSpy for `uuid.uuid3()` |
+| `uuid5` | Access NamespaceUUIDSpy for `uuid.uuid5()` |
+| `uuid6` | Access UUID6Mocker for `uuid.uuid6()` |
+| `uuid7` | Access UUID7Mocker for `uuid.uuid7()` |
+| `uuid8` | Access UUID8Mocker for `uuid.uuid8()` |
+| `reset()` | Reset all initialized sub-mockers |
+
+### UUID4Mocker (accessed via `mock_uuid.uuid4`)
 
 | Method | Description |
 |--------|-------------|

--- a/docs/guide/marker-api.md
+++ b/docs/guide/marker-api.md
@@ -210,7 +210,7 @@ def freeze_uuids_globally(request):
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `uuids` | `str`, `UUID`, or sequence | UUID(s) to return |
-| `seed` | `int` or `"node"` | Seed for reproducible generation |
+| `seed` | `int`, `Random`, or `"node"` | Seed for reproducible generation |
 | `on_exhausted` | `str` | `"cycle"`, `"random"`, or `"raise"` |
 | `ignore` | `list[str]` | Module prefixes to exclude from mocking |
 | `ignore_defaults` | `bool` | Include default ignore list (default `True`) |

--- a/docs/guide/marker-api.md
+++ b/docs/guide/marker-api.md
@@ -2,6 +2,51 @@
 
 The `@pytest.mark.freeze_uuid` marker integrates with pytest's marker system for declarative UUID mocking.
 
+## Version-Specific Markers
+
+Use version-specific markers for clarity and to enable version-specific features:
+
+| Marker | UUID Version | Extra Parameters |
+|--------|--------------|------------------|
+| `@pytest.mark.freeze_uuid4(...)` | uuid4 (recommended) | - |
+| `@pytest.mark.freeze_uuid1(...)` | uuid1 | `node`, `clock_seq` |
+| `@pytest.mark.freeze_uuid6(...)` | uuid6 | `node`, `clock_seq` |
+| `@pytest.mark.freeze_uuid7(...)` | uuid7 | - |
+| `@pytest.mark.freeze_uuid8(...)` | uuid8 | - |
+| `@pytest.mark.freeze_uuid(...)` | uuid4 (backward compatibility) | - |
+
+```python
+import uuid
+import pytest
+
+@pytest.mark.freeze_uuid4("12345678-1234-4678-8234-567812345678")
+def test_uuid4():
+    assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
+
+@pytest.mark.freeze_uuid1(seed=42, node=0x123456789abc)
+def test_uuid1_with_node():
+    result = uuid.uuid1()
+    assert result.node == 0x123456789abc
+
+@pytest.mark.freeze_uuid7(seed=42)
+def test_uuid7():
+    result = uuid.uuid7()
+    assert result.version == 7
+```
+
+### Stacking Multiple Version Markers
+
+Mock multiple UUID versions in the same test:
+
+```python
+@pytest.mark.freeze_uuid4("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+@pytest.mark.freeze_uuid1(seed=42)
+def test_multiple_versions():
+    assert str(uuid.uuid4()) == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    result1 = uuid.uuid1()
+    assert result1.version == 1
+```
+
 ## Basic Usage
 
 ```python
@@ -169,3 +214,5 @@ def freeze_uuids_globally(request):
 | `on_exhausted` | `str` | `"cycle"`, `"random"`, or `"raise"` |
 | `ignore` | `list[str]` | Module prefixes to exclude from mocking |
 | `ignore_defaults` | `bool` | Include default ignore list (default `True`) |
+| `node` | `int` | Fixed MAC address for uuid1/uuid6 markers |
+| `clock_seq` | `int` | Fixed clock sequence for uuid1/uuid6 markers |

--- a/docs/guide/spy-mode.md
+++ b/docs/guide/spy-mode.md
@@ -26,27 +26,27 @@ def test_user_generates_uuid(spy_uuid):
 
 ## Switching to Spy Mode
 
-Use `mock_uuid.spy()` to switch from mocked to real UUIDs mid-test:
+Use `mock_uuid.uuid4.spy()` to switch from mocked to real UUIDs mid-test:
 
 ```python
 import uuid
 
 def test_start_mocked_then_spy(mock_uuid):
     """Start with mocked UUIDs, then switch to real ones."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     first = uuid.uuid4()  # Mocked
 
-    mock_uuid.spy()  # Switch to spy mode
+    mock_uuid.uuid4.spy()  # Switch to spy mode
     second = uuid.uuid4()  # Real random UUID
 
     assert str(first) == "12345678-1234-4678-8234-567812345678"
     assert first != second  # second is random
-    assert mock_uuid.mocked_count == 1
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.mocked_count == 1
+    assert mock_uuid.uuid4.real_count == 1
 ```
 
 !!! tip "When to use which"
-    Use `spy_uuid` when you never need mocking in the test. Use `mock_uuid.spy()` when you need to switch between mocked and real UUIDs within the same test.
+    Use `spy_uuid` when you never need mocking in the test. Use `mock_uuid.uuid4.spy()` when you need to switch between mocked and real UUIDs within the same test.
 
 ## Call Tracking
 
@@ -123,24 +123,24 @@ import uuid
 
 def test_mixed_mocked_and_real(mock_uuid):
     """Track both mocked calls and real calls from ignored modules."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("mylib")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("mylib")
 
     uuid.uuid4()              # Mocked (direct call)
     mylib.create_record()     # Real (from ignored module)
     uuid.uuid4()              # Mocked (direct call)
 
     # Count by type
-    assert mock_uuid.call_count == 3
-    assert mock_uuid.mocked_count == 2
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.call_count == 3
+    assert mock_uuid.uuid4.mocked_count == 2
+    assert mock_uuid.uuid4.real_count == 1
 
     # Access only real calls
-    for call in mock_uuid.real_calls:
+    for call in mock_uuid.uuid4.real_calls:
         print(f"Real UUID from {call.caller_module}: {call.uuid}")
 
     # Access only mocked calls
-    for call in mock_uuid.mocked_calls:
+    for call in mock_uuid.uuid4.mocked_calls:
         assert call.was_mocked is True
 ```
 

--- a/docs/guide/spy-mode.md
+++ b/docs/guide/spy-mode.md
@@ -157,3 +157,28 @@ The `UUIDCall` dataclass contains:
 | `caller_line` | Line number of the call |
 | `caller_function` | Function name where the call originated |
 | `caller_qualname` | Qualified name (e.g., `MyClass.method` or `outer.<locals>.inner`) |
+
+## Thread Safety
+
+Call tracking is fully thread-safe. If your test code spawns multiple threads that call UUID functions concurrently, all calls will be accurately tracked:
+
+```python
+import threading
+import uuid
+
+def test_concurrent_tracking(spy_uuid):
+    """Thread-safe call tracking with concurrent UUID generation."""
+    def generate_uuids():
+        for _ in range(10):
+            uuid.uuid4()
+
+    threads = [threading.Thread(target=generate_uuids) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert spy_uuid.call_count == 40  # All calls tracked accurately
+```
+
+Each tracking operation uses per-instance locks to ensure consistent counting and metadata recording.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
   <img src="images/logo.svg" alt="pytest-uuid logo" width="365">
 </p>
 
-A pytest plugin for mocking `uuid.uuid4()` calls in your tests.
+A pytest plugin for mocking UUID generation in your tests. Supports uuid1, uuid3, uuid4, uuid5, uuid6, uuid7, and uuid8.
 
 [![PyPI version](https://img.shields.io/pypi/v/pytest-uuid.svg)](https://pypi.org/project/pytest-uuid/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -13,7 +13,7 @@ A pytest plugin for mocking `uuid.uuid4()` calls in your tests.
 
 ## Features
 
-- Mock `uuid.uuid4()` with deterministic values in your tests
+- Mock all UUID versions: uuid1, uuid3, uuid4, uuid5, uuid6, uuid7, uuid8
 - Works with both `import uuid` and `from uuid import uuid4` patterns
 - Multiple ways to mock: static, sequence, seeded, or node-seeded
 - Decorator, marker, and fixture APIs (inspired by freezegun)
@@ -23,6 +23,7 @@ A pytest plugin for mocking `uuid.uuid4()` calls in your tests.
 - Detailed call tracking with caller module/file info
 - Automatic cleanup after each test
 - Zero configuration required - just use the fixture
+- uuid6/uuid7/uuid8 support via [uuid6](https://pypi.org/project/uuid6/) backport (Python < 3.14)
 
 ## Quick Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,11 +31,11 @@ A pytest plugin for mocking UUID generation in your tests. Supports uuid1, uuid3
 import uuid
 
 def test_single_uuid(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 
 def test_multiple_uuids(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ The simplest way to use pytest-uuid is with the `mock_uuid` fixture:
 import uuid
 
 def test_single_uuid(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
 
@@ -24,7 +24,7 @@ Return different UUIDs for each call:
 
 ```python
 def test_multiple_uuids(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )
@@ -94,7 +94,7 @@ The main fixture for controlling `uuid.uuid4()` calls.
 import uuid
 
 def test_basic(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
 
@@ -104,7 +104,7 @@ Return the same UUID every time:
 
 ```python
 def test_static(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert uuid.uuid4() == uuid.uuid4()  # Same UUID
 ```
 
@@ -114,7 +114,7 @@ Return UUIDs from a list:
 
 ```python
 def test_sequence(mock_uuid):
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )
@@ -130,10 +130,10 @@ Generate reproducible UUIDs from a seed:
 
 ```python
 def test_seeded(mock_uuid):
-    mock_uuid.set_seed(42)
+    mock_uuid.uuid4.set_seed(42)
     first = uuid.uuid4()
 
-    mock_uuid.set_seed(42)  # Reset to same seed
+    mock_uuid.uuid4.set_seed(42)  # Reset to same seed
     assert uuid.uuid4() == first  # Same UUID
 ```
 
@@ -143,7 +143,7 @@ Derive the seed from the test's node ID:
 
 ```python
 def test_node_seeded(mock_uuid):
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     # Same test always produces the same sequence
 ```
 
@@ -153,12 +153,12 @@ Use the `seed` property to see the actual seed being used:
 
 ```python
 def test_inspect_seed(mock_uuid):
-    mock_uuid.set_seed(42)
-    assert mock_uuid.seed == 42
+    mock_uuid.uuid4.set_seed(42)
+    assert mock_uuid.uuid4.seed == 42
 
 def test_inspect_node_seed(mock_uuid):
-    mock_uuid.set_seed_from_node()
-    print(f"Using seed: {mock_uuid.seed}")  # e.g., 8427193654
+    mock_uuid.uuid4.set_seed_from_node()
+    print(f"Using seed: {mock_uuid.uuid4.seed}")  # e.g., 8427193654
 ```
 
 ### Exhaustion Behavior
@@ -169,8 +169,8 @@ Control what happens when a UUID sequence is exhausted:
 from pytest_uuid import UUIDsExhaustedError
 
 def test_exhaustion_raise(mock_uuid):
-    mock_uuid.set_exhaustion_behavior("raise")
-    mock_uuid.set("11111111-1111-4111-8111-111111111111")
+    mock_uuid.uuid4.set_exhaustion_behavior("raise")
+    mock_uuid.uuid4.set("11111111-1111-4111-8111-111111111111")
 
     uuid.uuid4()  # Returns the UUID
 
@@ -189,8 +189,8 @@ Exclude specific packages from UUID mocking:
 
 ```python
 def test_with_ignored_modules(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_ignore("sqlalchemy", "celery")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_ignore("sqlalchemy", "celery")
 
     # Direct calls are mocked
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
@@ -206,10 +206,10 @@ Reset the fixture to its initial state:
 
 ```python
 def test_reset(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     uuid.uuid4()
 
-    mock_uuid.reset()
+    mock_uuid.uuid4.reset()
     # Back to initial state - no UUIDs configured
 ```
 
@@ -227,7 +227,7 @@ def create_user():
 # tests/test_models.py
 def test_create_user(mock_uuid_factory):
     with mock_uuid_factory("myapp.models") as mocker:
-        mocker.set("12345678-1234-4678-8234-567812345678")
+        mocker.uuid4.set("12345678-1234-4678-8234-567812345678")
         user = create_user()
         assert user["id"] == "12345678-1234-4678-8234-567812345678"
 ```
@@ -388,20 +388,20 @@ def test_user_generates_uuid(spy_uuid):
 
 ## Switching to Spy Mode
 
-Use `mock_uuid.spy()` to switch from mocked to real UUIDs mid-test:
+Use `mock_uuid.uuid4.spy()` to switch from mocked to real UUIDs mid-test:
 
 ```python
 def test_start_mocked_then_spy(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     first = uuid.uuid4()  # Mocked
 
-    mock_uuid.spy()  # Switch to spy mode
+    mock_uuid.uuid4.spy()  # Switch to spy mode
     second = uuid.uuid4()  # Real random UUID
 
     assert str(first) == "12345678-1234-4678-8234-567812345678"
     assert first != second
-    assert mock_uuid.mocked_count == 1
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.mocked_count == 1
+    assert mock_uuid.uuid4.real_count == 1
 ```
 
 ## Call Tracking

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,8 +1,8 @@
 # pytest-uuid
 
-> A pytest plugin for mocking `uuid.uuid4()` calls with deterministic values. Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
+> A pytest plugin for mocking UUID generation in tests. Supports uuid1, uuid3, uuid4, uuid5, uuid6, uuid7, and uuid8. Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
 
-pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, and module ignore lists.
+pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, module ignore lists, and support for all UUID versions including RFC 9562 (uuid6/uuid7/uuid8 via backport on Python < 3.14).
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,8 +1,8 @@
 # pytest-uuid
 
-> A pytest plugin for mocking UUID generation in tests. Supports uuid1, uuid3, uuid4, uuid5, uuid6, uuid7, and uuid8. Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
+> A pytest plugin for mocking UUID generation in tests. Supports mocking uuid1, uuid4, uuid6, uuid7, and uuid8. Supports spy-only tracking for uuid3 and uuid5 (deterministic hash-based UUIDs). Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
 
-pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, module ignore lists, and support for all UUID versions including RFC 9562 (uuid6/uuid7/uuid8 via backport on Python < 3.14).
+pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, module ignore lists, thread-safe call tracking, and support for all UUID versions including RFC 9562 (uuid6/uuid7/uuid8 via backport on Python < 3.14).
 
 ---
 
@@ -38,9 +38,9 @@ def test_multiple_uuids(mock_uuid):
 
 ```python
 import uuid
-from pytest_uuid import freeze_uuid
+from pytest_uuid import freeze_uuid4
 
-@freeze_uuid("12345678-1234-4678-8234-567812345678")
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
 def test_with_decorator():
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
@@ -51,7 +51,7 @@ def test_with_decorator():
 import uuid
 import pytest
 
-@pytest.mark.freeze_uuid("12345678-1234-4678-8234-567812345678")
+@pytest.mark.freeze_uuid4("12345678-1234-4678-8234-567812345678")
 def test_with_marker():
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
@@ -61,7 +61,9 @@ def test_with_marker():
 For reproducible but not hardcoded UUIDs:
 
 ```python
-@freeze_uuid(seed=42)
+from pytest_uuid import freeze_uuid4
+
+@freeze_uuid4(seed=42)
 def test_seeded():
     result = uuid.uuid4()
     assert result.version == 4
@@ -72,7 +74,7 @@ def test_seeded():
 Each test gets deterministic UUIDs based on its name:
 
 ```python
-@pytest.mark.freeze_uuid(seed="node")
+@pytest.mark.freeze_uuid4(seed="node")
 def test_node_seeded():
     result = uuid.uuid4()
     assert result.version == 4
@@ -86,7 +88,7 @@ Node-seeded UUIDs give you deterministic, reproducible tests without hardcoding 
 
 ## mock_uuid Fixture
 
-The main fixture for controlling `uuid.uuid4()` calls.
+The main fixture for controlling UUID generation. It's a container with sub-mockers for each UUID version.
 
 ### Basic Usage
 
@@ -97,6 +99,20 @@ def test_basic(mock_uuid):
     mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
+
+### UUID Version Sub-Mockers
+
+The `mock_uuid` fixture provides access to version-specific mockers:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `mock_uuid.uuid1` | `UUID1Mocker` | Mock uuid.uuid1() with `set_node()`, `set_clock_seq()` |
+| `mock_uuid.uuid3` | `NamespaceUUIDSpy` | Spy-only (deterministic) - track calls with namespace/name |
+| `mock_uuid.uuid4` | `UUID4Mocker` | Mock uuid.uuid4() with `set_default()` |
+| `mock_uuid.uuid5` | `NamespaceUUIDSpy` | Spy-only (deterministic) - track calls with namespace/name |
+| `mock_uuid.uuid6` | `UUID6Mocker` | Mock uuid.uuid6() with `set_node()`, `set_clock_seq()` |
+| `mock_uuid.uuid7` | `UUID7Mocker` | Mock uuid.uuid7() |
+| `mock_uuid.uuid8` | `UUID8Mocker` | Mock uuid.uuid8() |
 
 ### Static UUIDs
 
@@ -166,6 +182,7 @@ def test_inspect_node_seed(mock_uuid):
 Control what happens when a UUID sequence is exhausted:
 
 ```python
+import pytest
 from pytest_uuid import UUIDsExhaustedError
 
 def test_exhaustion_raise(mock_uuid):
@@ -213,6 +230,63 @@ def test_reset(mock_uuid):
     # Back to initial state - no UUIDs configured
 ```
 
+## UUID1 (Time-Based)
+
+```python
+def test_uuid1(mock_uuid):
+    mock_uuid.uuid1.set("12345678-1234-1678-8234-567812345678")
+    result = uuid.uuid1()
+    assert result.version == 1
+
+def test_uuid1_with_node(mock_uuid):
+    mock_uuid.uuid1.set_seed(42)
+    mock_uuid.uuid1.set_node(0x123456789abc)  # Fixed MAC address
+    mock_uuid.uuid1.set_clock_seq(0x1234)      # Fixed clock sequence
+    result = uuid.uuid1()
+```
+
+## UUID3/UUID5 (Namespace-Based, Spy-Only)
+
+uuid3 and uuid5 are deterministic (same inputs = same output), so they only support spy mode:
+
+```python
+def test_uuid5_tracking(mock_uuid):
+    # Tracking is enabled by default
+    result = uuid.uuid5(uuid.NAMESPACE_DNS, "example.com")
+
+    assert mock_uuid.uuid5.call_count == 1
+    assert mock_uuid.uuid5.calls[0].namespace == uuid.NAMESPACE_DNS
+    assert mock_uuid.uuid5.calls[0].name == "example.com"
+```
+
+## UUID6/UUID7/UUID8 (RFC 9562)
+
+Requires Python 3.14+ or the `uuid6` package on earlier versions:
+
+```python
+def test_uuid7(mock_uuid):
+    mock_uuid.uuid7.set_seed(42)
+    result = uuid.uuid7()
+    assert result.version == 7
+```
+
+## Independent Call Tracking
+
+Each UUID version is tracked independently:
+
+```python
+def test_all_versions_independent(mock_uuid):
+    mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")
+    mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
+
+    uuid.uuid4()
+    uuid.uuid4()
+    uuid.uuid1()
+
+    assert mock_uuid.uuid4.call_count == 2
+    assert mock_uuid.uuid1.call_count == 1
+```
+
 ## mock_uuid_factory Fixture
 
 For module-specific mocking:
@@ -234,10 +308,11 @@ def test_create_user(mock_uuid_factory):
 
 ## Methods Reference
 
+### Common Methods (All Version Mockers)
+
 | Method | Description |
 |--------|-------------|
 | `set(*uuids)` | Set one or more UUIDs to return (cycles by default) |
-| `set_default(uuid)` | Set a default UUID for all calls |
 | `set_seed(seed)` | Set a seed for reproducible generation |
 | `set_seed_from_node()` | Use test node ID as seed |
 | `set_exhaustion_behavior(behavior)` | Set behavior when sequence exhausted |
@@ -245,19 +320,51 @@ def test_create_user(mock_uuid_factory):
 | `reset()` | Reset to initial state |
 | `set_ignore(*module_prefixes)` | Set modules to ignore |
 
+### UUID4-Specific Methods
+
+| Method | Description |
+|--------|-------------|
+| `set_default(uuid)` | Set a default UUID for all calls |
+
+### UUID1/UUID6-Specific Methods
+
+| Method | Description |
+|--------|-------------|
+| `set_node(node)` | Set fixed 48-bit MAC address |
+| `set_clock_seq(clock_seq)` | Set fixed 14-bit clock sequence |
+
+### NamespaceUUIDSpy Methods (UUID3/UUID5)
+
+| Method | Description |
+|--------|-------------|
+| `enable()` | Start tracking calls |
+| `disable()` | Stop tracking calls |
+| `reset()` | Reset tracking data |
+
 ---
 
 # Decorator API
 
-The `@freeze_uuid` decorator provides a clean way to configure UUID mocking at the function or class level.
+The `@freeze_uuid4` decorator (and version-specific variants) provides a clean way to configure UUID mocking at the function or class level.
+
+## Version-Specific Decorators
+
+| Decorator | UUID Version |
+|-----------|--------------|
+| `@freeze_uuid4(...)` | uuid4 (recommended) |
+| `@freeze_uuid1(...)` | uuid1 |
+| `@freeze_uuid6(...)` | uuid6 |
+| `@freeze_uuid7(...)` | uuid7 |
+| `@freeze_uuid8(...)` | uuid8 |
+| `@freeze_uuid(...)` | uuid4 (backward compatibility alias) |
 
 ## Basic Usage
 
 ```python
 import uuid
-from pytest_uuid import freeze_uuid
+from pytest_uuid import freeze_uuid4
 
-@freeze_uuid("12345678-1234-4678-8234-567812345678")
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
 def test_with_decorator():
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
@@ -267,7 +374,7 @@ def test_with_decorator():
 Pass multiple UUIDs as a list:
 
 ```python
-@freeze_uuid([
+@freeze_uuid4([
     "11111111-1111-4111-8111-111111111111",
     "22222222-2222-4222-8222-222222222222",
 ])
@@ -279,7 +386,7 @@ def test_sequence():
 ## Seeded UUIDs
 
 ```python
-@freeze_uuid(seed=42)
+@freeze_uuid4(seed=42)
 def test_seeded():
     result = uuid.uuid4()
     assert result.version == 4
@@ -293,7 +400,7 @@ import random
 rng = random.Random(42)
 rng.random()  # Advance the state
 
-@freeze_uuid(seed=rng)
+@freeze_uuid4(seed=rng)
 def test_custom_rng():
     result = uuid.uuid4()
 ```
@@ -301,7 +408,10 @@ def test_custom_rng():
 ## Exhaustion Behavior
 
 ```python
-@freeze_uuid(
+import pytest
+from pytest_uuid import freeze_uuid4, UUIDsExhaustedError
+
+@freeze_uuid4(
     ["11111111-1111-4111-8111-111111111111"],
     on_exhausted="raise",
 )
@@ -316,7 +426,7 @@ Options: `"cycle"` (default), `"random"`, `"raise"`
 ## Ignoring Modules
 
 ```python
-@freeze_uuid("12345678-1234-4678-8234-567812345678", ignore=["sqlalchemy"])
+@freeze_uuid4("12345678-1234-4678-8234-567812345678", ignore=["sqlalchemy"])
 def test_with_ignored():
     assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 ```
@@ -324,15 +434,26 @@ def test_with_ignored():
 ## Opting Out of Default Ignores
 
 ```python
-@freeze_uuid("12345678-1234-4678-8234-567812345678", ignore_defaults=False)
+@freeze_uuid4("12345678-1234-4678-8234-567812345678", ignore_defaults=False)
 def test_mock_everything():
     pass
+```
+
+## UUID1 with Node and Clock Sequence
+
+```python
+from pytest_uuid import freeze_uuid1
+
+@freeze_uuid1(seed=42, node=0x123456789abc, clock_seq=0x1234)
+def test_uuid1():
+    result = uuid.uuid1()
+    assert result.version == 1
 ```
 
 ## Class-Level Decorator
 
 ```python
-@freeze_uuid("12345678-1234-4678-8234-567812345678")
+@freeze_uuid4("12345678-1234-4678-8234-567812345678")
 class TestUserService:
     def test_create(self):
         assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
@@ -344,9 +465,12 @@ class TestUserService:
 ## Context Manager
 
 ```python
+from pytest_uuid import freeze_uuid4
+
 def test_context_manager():
-    with freeze_uuid("12345678-1234-4678-8234-567812345678"):
+    with freeze_uuid4("12345678-1234-4678-8234-567812345678") as freezer:
         assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
+        print(f"Call count: {freezer.call_count}")
 
     # Original uuid.uuid4 is restored
 ```
@@ -360,12 +484,77 @@ def test_context_manager():
 | `on_exhausted` | `str` | `"cycle"`, `"random"`, or `"raise"` |
 | `ignore` | `list[str]` | Module prefixes to exclude from mocking |
 | `ignore_defaults` | `bool` | Include default ignore list (default `True`) |
+| `node` | `int` | Fixed MAC address for uuid1/uuid6 |
+| `clock_seq` | `int` | Fixed clock sequence for uuid1/uuid6 |
+
+---
+
+# Marker API
+
+Version-specific markers for declarative UUID mocking.
+
+## Version-Specific Markers
+
+| Marker | UUID Version |
+|--------|--------------|
+| `@pytest.mark.freeze_uuid4(...)` | uuid4 (recommended) |
+| `@pytest.mark.freeze_uuid1(...)` | uuid1 |
+| `@pytest.mark.freeze_uuid6(...)` | uuid6 |
+| `@pytest.mark.freeze_uuid7(...)` | uuid7 |
+| `@pytest.mark.freeze_uuid8(...)` | uuid8 |
+| `@pytest.mark.freeze_uuid(...)` | uuid4 (backward compatibility) |
+
+## Basic Usage
+
+```python
+import uuid
+import pytest
+
+@pytest.mark.freeze_uuid4("12345678-1234-4678-8234-567812345678")
+def test_with_marker():
+    assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
+```
+
+## Node-Seeded
+
+```python
+@pytest.mark.freeze_uuid4(seed="node")
+def test_node_seeded():
+    result = uuid.uuid4()
+    # Same test always produces the same UUIDs
+```
+
+## Class-Level Marker
+
+```python
+@pytest.mark.freeze_uuid4("12345678-1234-4678-8234-567812345678")
+class TestUserService:
+    def test_create(self):
+        assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
+```
+
+## Module-Level Marker
+
+```python
+# tests/test_users.py
+import pytest
+
+pytestmark = pytest.mark.freeze_uuid4(seed="node")
+
+def test_create_user():
+    # All tests in this module use node-seeded UUIDs
+    pass
+```
+
+## Parameters
+
+Same as decorator API, except `seed` cannot be a `Random` instance (markers must be serializable).
 
 ---
 
 # Spy Mode
 
-Spy mode tracks `uuid.uuid4()` calls without mocking them.
+Spy mode tracks UUID calls without mocking them.
 
 ## spy_uuid Fixture
 
@@ -425,8 +614,31 @@ def test_call_details(spy_uuid):
     call = spy_uuid.calls[0]
     assert call.uuid is not None
     assert call.was_mocked is False
+    assert call.uuid_version == 4
     assert call.caller_module is not None
     assert call.caller_file is not None
+```
+
+## Thread Safety
+
+Call tracking is fully thread-safe:
+
+```python
+import threading
+import uuid
+
+def test_concurrent_tracking(spy_uuid):
+    def generate_uuids():
+        for _ in range(10):
+            uuid.uuid4()
+
+    threads = [threading.Thread(target=generate_uuids) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert spy_uuid.call_count == 40  # All calls tracked accurately
 ```
 
 ## Properties
@@ -447,15 +659,30 @@ def test_call_details(spy_uuid):
 
 ## UUIDCall Dataclass
 
-| Field | Description |
-|-------|-------------|
-| `uuid` | The UUID that was returned |
-| `was_mocked` | `True` if mocked, `False` if real |
-| `caller_module` | Name of the module that made the call |
-| `caller_file` | File path where the call originated |
-| `caller_line` | Line number of the call |
-| `caller_function` | Function name where the call originated |
-| `caller_qualname` | Qualified name (e.g., `MyClass.method`) |
+| Field | Type | Description |
+|-------|------|-------------|
+| `uuid` | `UUID` | The UUID that was returned |
+| `was_mocked` | `bool` | `True` if mocked, `False` if real |
+| `uuid_version` | `int` | UUID version (1, 3, 4, 5, 6, 7, or 8) |
+| `caller_module` | `str \| None` | Name of the module that made the call |
+| `caller_file` | `str \| None` | File path where the call originated |
+| `caller_line` | `int \| None` | Line number of the call |
+| `caller_function` | `str \| None` | Function name where the call originated |
+| `caller_qualname` | `str \| None` | Qualified name (e.g., `MyClass.method`) |
+
+## NamespaceUUIDCall Dataclass (for uuid3/uuid5)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `uuid` | `UUID` | The UUID that was returned |
+| `uuid_version` | `int` | UUID version (3 or 5) |
+| `namespace` | `UUID` | The namespace UUID used |
+| `name` | `str` | The name string used |
+| `caller_module` | `str \| None` | Name of the module that made the call |
+| `caller_file` | `str \| None` | File path where the call originated |
+| `caller_line` | `int \| None` | Line number of the call |
+| `caller_function` | `str \| None` | Function name where the call originated |
+| `caller_qualname` | `str \| None` | Qualified name |
 
 ---
 
@@ -515,28 +742,39 @@ The ignore check inspects the entire call stack:
 
 ### mock_uuid
 
-Main fixture for controlling `uuid.uuid4()` calls.
+Main fixture for controlling UUID generation. Container with version-specific sub-mockers.
 
-**Methods:**
+**Container Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `uuid1` | `UUID1Mocker` | UUID1 mocker with `set_node()`, `set_clock_seq()` |
+| `uuid3` | `NamespaceUUIDSpy` | UUID3 spy (tracking only) |
+| `uuid4` | `UUID4Mocker` | UUID4 mocker with `set_default()` |
+| `uuid5` | `NamespaceUUIDSpy` | UUID5 spy (tracking only) |
+| `uuid6` | `UUID6Mocker` | UUID6 mocker with `set_node()`, `set_clock_seq()` |
+| `uuid7` | `UUID7Mocker` | UUID7 mocker |
+| `uuid8` | `UUID8Mocker` | UUID8 mocker |
+
+**Common Mocker Methods:**
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `set` | `set(*uuids: str \| UUID)` | Set one or more UUIDs to return |
-| `set_default` | `set_default(uuid: str \| UUID)` | Set a default UUID for all calls |
-| `set_seed` | `set_seed(seed: int)` | Set a seed for reproducible generation |
+| `set_seed` | `set_seed(seed: int \| Random)` | Set a seed for reproducible generation |
 | `set_seed_from_node` | `set_seed_from_node()` | Use test node ID as seed |
 | `set_exhaustion_behavior` | `set_exhaustion_behavior(behavior: str)` | Set exhaustion behavior |
 | `set_ignore` | `set_ignore(*module_prefixes: str)` | Set modules to ignore |
 | `spy` | `spy()` | Switch to spy mode |
 | `reset` | `reset()` | Reset to initial state |
 
-**Properties:**
+**Common Mocker Properties:**
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `seed` | `int \| None` | The active seed value |
 | `generator` | `UUIDGenerator \| None` | The current UUID generator |
-| `call_count` | `int` | Total uuid4 calls |
+| `call_count` | `int` | Total calls |
 | `generated_uuids` | `list[UUID]` | All returned UUIDs |
 | `last_uuid` | `UUID \| None` | Most recent UUID |
 | `calls` | `list[UUIDCall]` | Call records with metadata |
@@ -544,6 +782,28 @@ Main fixture for controlling `uuid.uuid4()` calls.
 | `real_calls` | `list[UUIDCall]` | Only real calls |
 | `mocked_count` | `int` | Number of mocked calls |
 | `real_count` | `int` | Number of real calls |
+
+**UUID4Mocker-Specific:**
+
+| Method | Description |
+|--------|-------------|
+| `set_default(uuid)` | Set a default UUID for all calls |
+
+**UUID1Mocker/UUID6Mocker-Specific:**
+
+| Method | Description |
+|--------|-------------|
+| `set_node(node: int)` | Set fixed 48-bit MAC address |
+| `set_clock_seq(clock_seq: int)` | Set fixed 14-bit clock sequence |
+
+**NamespaceUUIDSpy-Specific (uuid3/uuid5):**
+
+| Property/Method | Description |
+|-----------------|-------------|
+| `enabled` | Whether tracking is enabled |
+| `enable()` | Start tracking calls |
+| `disable()` | Stop tracking calls |
+| `calls` | `list[NamespaceUUIDCall]` with namespace/name info |
 
 ### spy_uuid
 
@@ -560,42 +820,68 @@ Spy fixture that tracks `uuid.uuid4()` calls without mocking.
 
 ## Decorator / Context Manager
 
-### freeze_uuid
+### freeze_uuid4, freeze_uuid1, freeze_uuid6, freeze_uuid7, freeze_uuid8
 
 ```python
-from pytest_uuid import freeze_uuid
+from pytest_uuid import freeze_uuid4, freeze_uuid1, freeze_uuid6, freeze_uuid7, freeze_uuid8
 ```
 
 **Signature:**
 
 ```python
-freeze_uuid(
+freeze_uuid4(
     uuids: str | UUID | Sequence[str | UUID] = None,
     *,
     seed: int | Random | Literal["node"] = None,
     on_exhausted: Literal["cycle", "random", "raise"] = "cycle",
     ignore: Sequence[str] = None,
+    ignore_defaults: bool = True,
 )
 ```
 
-## Marker
+For `freeze_uuid1` and `freeze_uuid6`, additional parameters:
+- `node: int` - Fixed 48-bit MAC address
+- `clock_seq: int` - Fixed 14-bit clock sequence
 
-### @pytest.mark.freeze_uuid
+## Markers
+
+### @pytest.mark.freeze_uuid4, freeze_uuid1, etc.
 
 ```python
-@pytest.mark.freeze_uuid(uuids, *, seed=None, on_exhausted="cycle", ignore=None)
+@pytest.mark.freeze_uuid4(uuids, *, seed=None, on_exhausted="cycle", ignore=None, ignore_defaults=True)
 ```
 
-Same parameters as `freeze_uuid` decorator, except `seed` cannot be a `Random` instance.
+Same parameters as decorator API, except `seed` cannot be a `Random` instance.
 
 ## Types
 
 ### UUIDCall
 
-Dataclass containing call metadata.
-
 ```python
 from pytest_uuid.types import UUIDCall
+```
+
+Dataclass containing call metadata for uuid1, uuid4, uuid6, uuid7, uuid8.
+
+### NamespaceUUIDCall
+
+```python
+from pytest_uuid.types import NamespaceUUIDCall
+```
+
+Dataclass containing call metadata for uuid3, uuid5, including `namespace` and `name` fields.
+
+### Protocols (for type annotations)
+
+```python
+from pytest_uuid import (
+    UUIDMockerProtocol,          # mock_uuid fixture type
+    UUIDSpyProtocol,             # spy_uuid fixture type
+    UUIDVersionMockerProtocol,   # Base mocker protocol
+    UUID4MockerProtocol,         # UUID4 mocker with set_default()
+    TimeBasedUUIDMockerProtocol, # UUID1/UUID6 with set_node(), set_clock_seq()
+    NamespaceUUIDSpyProtocol,    # UUID3/UUID5 spy
+)
 ```
 
 ### ExhaustionBehavior
@@ -650,11 +936,11 @@ When you write `from uuid import uuid4`, Python creates a **direct reference** t
 
 ## The Solution: Permanent Proxy
 
-pytest-uuid uses a **proxy function** that replaces `uuid.uuid4` at plugin initialization:
+pytest-uuid uses a **proxy function** that replaces `uuid.uuid4` (and other versions) at plugin initialization:
 
-1. Save original uuid.uuid4 function
-2. Replace uuid.uuid4 with proxy function
-3. Any code importing uuid4 after this gets the proxy
+1. Save original uuid functions
+2. Replace them with proxy functions
+3. Any code importing uuid functions after this gets the proxy
 
 The proxy is installed in `pytest_load_initial_conftests`, which runs **before** conftest files are loaded.
 
@@ -664,35 +950,48 @@ The proxy is installed in `pytest_load_initial_conftests`, which runs **before**
 # Simplified version
 _original_uuid4 = None
 _generator_stack = []  # Thread-safe stack of generators
+_generator_lock = threading.Lock()
 
 def _proxy_uuid4():
-    if _generator_stack:
-        generator = _generator_stack[-1]
+    with _generator_lock:
+        if _generator_stack:
+            generator = _generator_stack[-1]
+    if generator:
         return generator()
     return _original_uuid4()
 ```
 
-When you use `freeze_uuid`:
+When you use `freeze_uuid4`:
 1. `__enter__` pushes a generator onto the stack
 2. All `uuid.uuid4()` calls go through the proxy -> generator
 3. `__exit__` pops the generator from the stack
 
 ## Thread Safety
 
-The proxy uses a thread-safe global stack protected by a lock:
+Both UUID generation and call tracking are fully thread-safe:
+
+**UUID Generation:**
+- The proxy uses a thread-safe global stack protected by a lock
 - All threads see the same active generator
-- Lock protects stack operations
-- For pytest-xdist, each worker is a separate process with its own proxy
+- Lock protects stack operations (push/pop/read)
+- Generator is called outside the lock to avoid holding it during user code
+
+**Call Tracking:**
+- All tracking properties (`call_count`, `calls`, `generated_uuids`, etc.) use per-instance locks
+- Multiple threads can safely call UUID functions and have their calls tracked accurately
+- Lock hold time is minimized by creating dataclasses outside the critical section
+
+For parallel test execution with pytest-xdist, each worker is a separate process with its own proxy and stack, so there's no cross-worker interference.
 
 ## Nested Contexts
 
 The stack-based approach supports nested contexts:
 
 ```python
-with freeze_uuid(seed=42):
+with freeze_uuid4(seed=42):
     uuid.uuid4()  # Uses seed=42 generator
 
-    with freeze_uuid(seed=99):
+    with freeze_uuid4(seed=99):
         uuid.uuid4()  # Uses seed=99 generator (inner)
 
     uuid.uuid4()  # Back to seed=42 generator
@@ -718,28 +1017,29 @@ pytest-uuid is a pytest plugin for mocking UUID generation with deterministic se
 
 ### Key Concepts
 
-- **`freeze_uuid` context manager** - Creates deterministic UUID sequences from a seed
-- **Proxy system** - A permanent proxy installed at `uuid.uuid4` that delegates to either the original function or a test generator
+- **`freeze_uuid4` context manager** - Creates deterministic UUID sequences from a seed
+- **Proxy system** - Permanent proxies installed at `uuid.uuid4`, `uuid.uuid1`, etc. that delegate to either the original function or a test generator
 - **Thread-safe stack** - Lock-protected generator stack for nested contexts and thread safety
-- **Call tracking** - Records which modules called uuid4 for debugging
+- **Thread-safe call tracking** - Per-instance locks for tracking call counts and metadata
 
 ## Critical Code Paths
 
 | Path | Purpose | Notes |
 |------|---------|-------|
 | `plugin.py:pytest_configure` | Plugin initialization, proxy installation | Runs once per session |
-| `_proxy.py` | UUID4 proxy and ContextVar management | Core of the patching system |
-| `_tracking.py` | Call tracking, caller info extraction | Performance-sensitive |
+| `_proxy.py` | UUID proxies and ContextVar management | Core of the patching system |
+| `_tracking.py` | Thread-safe call tracking, caller info extraction | Performance-sensitive |
 | `generators.py` | UUID generation strategies | Seedable random or sequential |
-| `api.py:UUIDFreezer` | The `freeze_uuid` context manager | User-facing API |
+| `api.py:UUIDFreezer` | The `freeze_uuid4` context manager | User-facing API |
 
 ## Module Responsibilities
 
 | Module | Responsibility |
 |--------|----------------|
-| `plugin.py` | Pytest hooks, fixtures, config loading |
-| `api.py` | Public API (`freeze_uuid`, `UUIDFreezer`) |
-| `_proxy.py` | Proxy function, ContextVar, generator management |
-| `_tracking.py` | Call tracking, caller info, qualname extraction |
-| `generators.py` | `SeededUUIDGenerator`, `SequentialUUIDGenerator`, etc. |
-| `types.py` | Protocol definitions for type checking |
+| `plugin.py` | Pytest hooks, fixtures, config loading, version mockers |
+| `api.py` | Public API (`freeze_uuid4`, `freeze_uuid1`, etc., `UUIDFreezer`) |
+| `_proxy.py` | Proxy functions, ContextVar, generator management |
+| `_tracking.py` | Thread-safe call tracking, caller info, qualname extraction |
+| `generators.py` | `SeededUUIDGenerator`, `SequenceUUIDGenerator`, etc. |
+| `config.py` | Configuration loading, `configure()` API |
+| `types.py` | Protocol definitions (`UUIDMockerProtocol`, etc.) for type checking |

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,7 @@ pytest-uuid provides fixtures, decorators, and markers for controlling UUID gene
 
 ## Source Code
 
+- [\_\_init\_\_.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/__init__.py): Main package entry point, exports all public API (`freeze_uuid4`, `freeze_uuid1`, etc., `configure`, fixtures, generators, type protocols)
 - [plugin.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/plugin.py): Pytest hooks, fixtures (`mock_uuid`, `spy_uuid`, `mock_uuid_factory`), and UUID mockers (`UUIDMocker`, `UUID4Mocker`, `UUID1Mocker`, `UUID6Mocker`, `UUID7Mocker`, `UUID8Mocker`, `NamespaceUUIDSpy` for uuid3/uuid5)
 - [api.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/api.py): Version-specific freeze functions (`freeze_uuid4`, `freeze_uuid1`, `freeze_uuid6`, `freeze_uuid7`, `freeze_uuid8`) and `UUIDFreezer` class
 - [_proxy.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_proxy.py): UUID proxy and generator stack for all UUID versions

--- a/llms.txt
+++ b/llms.txt
@@ -1,32 +1,35 @@
 # pytest-uuid
 
-> A pytest plugin for mocking UUID generation in tests. Supports uuid1, uuid3, uuid4, uuid5, uuid6, uuid7, and uuid8. Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
+> A pytest plugin for mocking UUID generation in tests. Supports mocking uuid1, uuid4, uuid6, uuid7, and uuid8. Supports spy-only tracking for uuid3 and uuid5 (deterministic hash-based UUIDs). Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
 
-pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, module ignore lists, and support for all UUID versions including RFC 9562 (uuid6/uuid7/uuid8 via backport on Python < 3.14).
+pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, module ignore lists, thread-safe call tracking, and support for all UUID versions including RFC 9562 (uuid6/uuid7/uuid8 via backport on Python < 3.14).
 
 ## Documentation
 
 - [README](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/README.md): Full documentation with examples for all APIs
 - [Quick Start](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/getting-started/quickstart.md): Get running in minutes
+- [Installation](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/getting-started/installation.md): Detailed installation instructions
 - [API Reference](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/api-reference.md): Complete API documentation
 
 ## Guides
 
-- [Fixture API](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/fixture-api.md): Using `mock_uuid` and `spy_uuid` fixtures
-- [Decorator API](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/decorator-api.md): Using `@freeze_uuid` decorator
-- [Marker API](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/marker-api.md): Using `@pytest.mark.freeze_uuid`
-- [Spy Mode](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/spy-mode.md): Track UUID calls without mocking
+- [Fixture API](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/fixture-api.md): Using `mock_uuid` and `spy_uuid` fixtures with all UUID versions
+- [Decorator API](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/decorator-api.md): Using `@freeze_uuid4`, `@freeze_uuid1`, etc. decorators
+- [Marker API](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/marker-api.md): Using `@pytest.mark.freeze_uuid4`, etc. markers
+- [Spy Mode](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/spy-mode.md): Track UUID calls without mocking (thread-safe)
 - [Configuration](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/configuration.md): pyproject.toml and programmatic config
 - [How It Works](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/docs/guide/how-it-works.md): Technical explanation of the proxy system
 
 ## Source Code
 
-- [plugin.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/plugin.py): Pytest hooks, fixtures, and UUID mockers (UUID1Mocker, UUID6/7/8Mocker, NamespaceUUIDSpy)
-- [api.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/api.py): `freeze_uuid` context manager/decorator
+- [plugin.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/plugin.py): Pytest hooks, fixtures (`mock_uuid`, `spy_uuid`, `mock_uuid_factory`), and UUID mockers (`UUIDMocker`, `UUID4Mocker`, `UUID1Mocker`, `UUID6Mocker`, `UUID7Mocker`, `UUID8Mocker`, `NamespaceUUIDSpy` for uuid3/uuid5)
+- [api.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/api.py): Version-specific freeze functions (`freeze_uuid4`, `freeze_uuid1`, `freeze_uuid6`, `freeze_uuid7`, `freeze_uuid8`) and `UUIDFreezer` class
 - [_proxy.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_proxy.py): UUID proxy and generator stack for all UUID versions
 - [_compat.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_compat.py): Python version compatibility for uuid6/uuid7/uuid8
-- [generators.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/generators.py): UUID generation strategies
-- [types.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/types.py): Type definitions and protocols
+- [_tracking.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_tracking.py): Thread-safe call tracking and caller info extraction
+- [generators.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/generators.py): UUID generation strategies (seeded, sequential, static)
+- [config.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/config.py): Configuration loading and `configure()` API
+- [types.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/types.py): Type definitions and protocols (`UUIDMockerProtocol`, `UUIDCall`, `NamespaceUUIDCall`)
 
 ## Optional
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # pytest-uuid
 
-> A pytest plugin for mocking `uuid.uuid4()` calls with deterministic values. Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
+> A pytest plugin for mocking UUID generation in tests. Supports uuid1, uuid3, uuid4, uuid5, uuid6, uuid7, and uuid8. Works with both `import uuid` and `from uuid import uuid4` patterns using a permanent proxy system.
 
-pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, and module ignore lists.
+pytest-uuid provides fixtures, decorators, and markers for controlling UUID generation in tests. Key features include static UUIDs, sequences, seeded generation, node-seeded reproducibility, spy mode for tracking without mocking, module ignore lists, and support for all UUID versions including RFC 9562 (uuid6/uuid7/uuid8 via backport on Python < 3.14).
 
 ## Documentation
 
@@ -21,9 +21,10 @@ pytest-uuid provides fixtures, decorators, and markers for controlling UUID gene
 
 ## Source Code
 
-- [plugin.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/plugin.py): Pytest hooks and fixtures
+- [plugin.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/plugin.py): Pytest hooks, fixtures, and UUID mockers (UUID1Mocker, UUID6/7/8Mocker, NamespaceUUIDSpy)
 - [api.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/api.py): `freeze_uuid` context manager/decorator
-- [_proxy.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_proxy.py): UUID proxy and generator stack
+- [_proxy.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_proxy.py): UUID proxy and generator stack for all UUID versions
+- [_compat.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/_compat.py): Python version compatibility for uuid6/uuid7/uuid8
 - [generators.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/generators.py): UUID generation strategies
 - [types.py](https://github.com/CaptainDriftwood/pytest-uuid/blob/master/src/pytest_uuid/types.py): Type definitions and protocols
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
     "pytest>=7.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
+    "uuid6>=2024.7.10; python_version < '3.14'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "pytest-uuid"
-version = "0.7.0"
+version = "1.0.0"
 description = "A pytest plugin for mocking uuid.uuid4() calls"
 readme = "README.md"
 license = "MIT"

--- a/src/pytest_uuid/__init__.py
+++ b/src/pytest_uuid/__init__.py
@@ -63,6 +63,9 @@ from pytest_uuid.config import (
 )
 from pytest_uuid.generators import (
     ExhaustionBehavior,
+    RandomUUID1Generator,
+    RandomUUID6Generator,
+    RandomUUID7Generator,
     RandomUUIDGenerator,
     SeededUUIDGenerator,
     SequenceUUIDGenerator,
@@ -103,6 +106,9 @@ __all__ = [
     "SequenceUUIDGenerator",
     "SeededUUIDGenerator",
     "RandomUUIDGenerator",
+    "RandomUUID1Generator",
+    "RandomUUID6Generator",
+    "RandomUUID7Generator",
     # Enums and Exceptions
     "ExhaustionBehavior",
     "UUIDsExhaustedError",

--- a/src/pytest_uuid/__init__.py
+++ b/src/pytest_uuid/__init__.py
@@ -37,17 +37,17 @@ Thread Safety:
 Example:
     # Fixture approach (most common)
     def test_user_creation(mock_uuid):
-        mock_uuid.set("12345678-1234-4678-8234-567812345678")
+        mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
         user = create_user()
         assert user.id == "12345678-1234-4678-8234-567812345678"
 
     # Decorator approach
-    @freeze_uuid("12345678-1234-4678-8234-567812345678")
+    @freeze_uuid4("12345678-1234-4678-8234-567812345678")
     def test_with_decorator():
         assert str(uuid.uuid4()) == "12345678-1234-4678-8234-567812345678"
 
     # Marker with node seeding (reproducible per-test)
-    @pytest.mark.freeze_uuid(seed="node")
+    @pytest.mark.freeze_uuid4(seed="node")
     def test_reproducible():
         result = uuid.uuid4()  # Same UUID every time this test runs
 """
@@ -102,9 +102,13 @@ from pytest_uuid.plugin import (
 )
 from pytest_uuid.types import (
     NamespaceUUIDCall,
+    NamespaceUUIDSpyProtocol,
+    TimeBasedUUIDMockerProtocol,
+    UUID4MockerProtocol,
     UUIDCall,
     UUIDMockerProtocol,
     UUIDSpyProtocol,
+    UUIDVersionMockerProtocol,
 )
 
 try:
@@ -150,6 +154,10 @@ __all__ = [
     "NamespaceUUIDCall",
     "UUIDMockerProtocol",
     "UUIDSpyProtocol",
+    "UUIDVersionMockerProtocol",
+    "UUID4MockerProtocol",
+    "TimeBasedUUIDMockerProtocol",
+    "NamespaceUUIDSpyProtocol",
     # Fixtures (for documentation - actual fixtures registered via plugin)
     "mock_uuid",
     "mock_uuid_factory",

--- a/src/pytest_uuid/__init__.py
+++ b/src/pytest_uuid/__init__.py
@@ -76,6 +76,7 @@ from pytest_uuid.generators import (
 from pytest_uuid.plugin import (
     NamespaceUUIDSpy,
     UUID1Mocker,
+    UUID4Mocker,
     UUID6Mocker,
     UUID7Mocker,
     UUID8Mocker,
@@ -130,6 +131,7 @@ __all__ = [
     "UUIDSpy",
     # Sub-mockers for specific UUID versions
     "UUID1Mocker",
+    "UUID4Mocker",
     "UUID6Mocker",
     "UUID7Mocker",
     "UUID8Mocker",

--- a/src/pytest_uuid/__init__.py
+++ b/src/pytest_uuid/__init__.py
@@ -54,7 +54,15 @@ Example:
 
 from importlib.metadata import PackageNotFoundError, version
 
-from pytest_uuid.api import UUIDFreezer, freeze_uuid
+from pytest_uuid.api import (
+    UUIDFreezer,
+    freeze_uuid,
+    freeze_uuid1,
+    freeze_uuid4,
+    freeze_uuid6,
+    freeze_uuid7,
+    freeze_uuid8,
+)
 from pytest_uuid.config import (
     configure,
     get_config,
@@ -66,12 +74,18 @@ from pytest_uuid.generators import (
     RandomUUID1Generator,
     RandomUUID6Generator,
     RandomUUID7Generator,
+    RandomUUID8Generator,
     RandomUUIDGenerator,
+    SeededUUID1Generator,
+    SeededUUID6Generator,
+    SeededUUID7Generator,
+    SeededUUID8Generator,
     SeededUUIDGenerator,
     SequenceUUIDGenerator,
     StaticUUIDGenerator,
     UUIDGenerator,
     UUIDsExhaustedError,
+    get_seeded_generator,
 )
 from pytest_uuid.plugin import (
     NamespaceUUIDSpy,
@@ -98,8 +112,15 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0+dev"
 __all__ = [
-    # Main API
+    # Main API - version-specific freeze functions
+    "freeze_uuid4",
+    "freeze_uuid1",
+    "freeze_uuid6",
+    "freeze_uuid7",
+    "freeze_uuid8",
+    # Backward compatibility alias
     "freeze_uuid",
+    # Freezer class
     "UUIDFreezer",
     # Configuration
     "configure",
@@ -111,10 +132,16 @@ __all__ = [
     "StaticUUIDGenerator",
     "SequenceUUIDGenerator",
     "SeededUUIDGenerator",
+    "SeededUUID1Generator",
+    "SeededUUID6Generator",
+    "SeededUUID7Generator",
+    "SeededUUID8Generator",
     "RandomUUIDGenerator",
     "RandomUUID1Generator",
     "RandomUUID6Generator",
     "RandomUUID7Generator",
+    "RandomUUID8Generator",
+    "get_seeded_generator",
     # Enums and Exceptions
     "ExhaustionBehavior",
     "UUIDsExhaustedError",

--- a/src/pytest_uuid/__init__.py
+++ b/src/pytest_uuid/__init__.py
@@ -74,6 +74,11 @@ from pytest_uuid.generators import (
     UUIDsExhaustedError,
 )
 from pytest_uuid.plugin import (
+    NamespaceUUIDSpy,
+    UUID1Mocker,
+    UUID6Mocker,
+    UUID7Mocker,
+    UUID8Mocker,
     UUIDMocker,
     UUIDSpy,
     mock_uuid,
@@ -123,4 +128,10 @@ __all__ = [
     "spy_uuid",
     "UUIDMocker",
     "UUIDSpy",
+    # Sub-mockers for specific UUID versions
+    "UUID1Mocker",
+    "UUID6Mocker",
+    "UUID7Mocker",
+    "UUID8Mocker",
+    "NamespaceUUIDSpy",
 ]

--- a/src/pytest_uuid/__init__.py
+++ b/src/pytest_uuid/__init__.py
@@ -77,7 +77,12 @@ from pytest_uuid.plugin import (
     mock_uuid_factory,
     spy_uuid,
 )
-from pytest_uuid.types import UUIDMockerProtocol, UUIDSpyProtocol
+from pytest_uuid.types import (
+    NamespaceUUIDCall,
+    UUIDCall,
+    UUIDMockerProtocol,
+    UUIDSpyProtocol,
+)
 
 try:
     __version__ = version("pytest-uuid")
@@ -101,7 +106,9 @@ __all__ = [
     # Enums and Exceptions
     "ExhaustionBehavior",
     "UUIDsExhaustedError",
-    # Type annotations
+    # Type annotations and call tracking
+    "UUIDCall",
+    "NamespaceUUIDCall",
     "UUIDMockerProtocol",
     "UUIDSpyProtocol",
     # Fixtures (for documentation - actual fixtures registered via plugin)

--- a/src/pytest_uuid/_compat.py
+++ b/src/pytest_uuid/_compat.py
@@ -1,0 +1,74 @@
+"""Compatibility layer for UUID functions across Python versions.
+
+This module provides version-aware imports for uuid6, uuid7, and uuid8 functions:
+- Python 3.14+: Uses stdlib uuid module
+- Python 3.9-3.13: Uses uuid6 backport package
+
+The uuid6 package is a conditional dependency (only installed on Python < 3.14).
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from typing import TYPE_CHECKING, Callable
+
+# Feature flags for conditional functionality
+HAS_UUID6_7_8: bool
+"""True if uuid6, uuid7, uuid8 functions are available (Python 3.14+ or uuid6 package)."""
+
+# Type alias for UUID generator functions
+UUIDFunc = Callable[..., uuid.UUID]
+
+# Version-aware imports for uuid6/uuid7/uuid8
+if sys.version_info >= (3, 14):
+    # Python 3.14+ has native support
+    from uuid import uuid6 as _uuid6
+    from uuid import uuid7 as _uuid7
+    from uuid import uuid8 as _uuid8
+
+    HAS_UUID6_7_8 = True
+else:
+    # Python 3.9-3.13: use uuid6 backport package
+    try:
+        from uuid6 import uuid6 as _uuid6
+        from uuid6 import uuid7 as _uuid7
+        from uuid6 import uuid8 as _uuid8
+
+        HAS_UUID6_7_8 = True
+    except ImportError:
+        # uuid6 package not installed - functions unavailable
+        HAS_UUID6_7_8 = False
+        _uuid6 = None  # type: ignore[assignment]
+        _uuid7 = None  # type: ignore[assignment]
+        _uuid8 = None  # type: ignore[assignment]
+
+
+# Export the functions (may be None if not available)
+uuid6: UUIDFunc | None = _uuid6 if HAS_UUID6_7_8 else None
+uuid7: UUIDFunc | None = _uuid7 if HAS_UUID6_7_8 else None
+uuid8: UUIDFunc | None = _uuid8 if HAS_UUID6_7_8 else None
+
+
+def require_uuid6_7_8(func_name: str) -> None:
+    """Raise an error if uuid6/7/8 functions are not available.
+
+    Args:
+        func_name: The function name being requested (for error message).
+
+    Raises:
+        RuntimeError: If uuid6/7/8 are not available.
+    """
+    if not HAS_UUID6_7_8:
+        raise RuntimeError(
+            f"{func_name} mocking requires Python 3.14+ or the 'uuid6' package. "
+            f"Install with: pip install uuid6"
+        )
+
+
+# For type checking, provide proper types regardless of runtime availability
+if TYPE_CHECKING:
+    # These are always available for type checking purposes
+    uuid6: UUIDFunc  # type: ignore[no-redef]
+    uuid7: UUIDFunc  # type: ignore[no-redef]
+    uuid8: UUIDFunc  # type: ignore[no-redef]

--- a/src/pytest_uuid/_proxy.py
+++ b/src/pytest_uuid/_proxy.py
@@ -1,30 +1,39 @@
-"""Permanent proxy for uuid.uuid4() that enables context-aware mocking.
+"""Permanent proxies for UUID functions that enable context-aware mocking.
 
 This module implements a proxy-based patching approach that solves several
 edge cases with the traditional attribute-patching approach:
 
 1. Pydantic default_factory=uuid4 - captures function at class definition
 2. Late imports during freeze_uuid context - stale patched functions
-3. Closures and data structures storing uuid4 references
+3. Closures and data structures storing uuid function references
 
 Architecture:
-    1. At plugin load (pytest_configure), install _proxy_uuid4 as uuid.uuid4
-    2. Any code that imports uuid4 (before or after) gets the proxy
+    1. At plugin load (pytest_configure), install proxies for all uuid functions
+    2. Any code that imports uuid functions (before or after) gets the proxy
     3. The proxy checks a thread-safe stack for the current generator
-    4. If a generator is set, use it; otherwise, call original uuid4
+    4. If a generator is set, use it; otherwise, call original function
 
 Thread Safety:
-    Uses a thread-safe global stack protected by a lock. This ensures:
+    Uses thread-safe global stacks protected by a lock. This ensures:
     - All threads see the same active generator (unlike ContextVar)
     - Nested contexts work correctly (stack-based)
-    - Thread-safe access to the generator stack
+    - Thread-safe access to the generator stacks
+
+Supported UUID Functions:
+    - uuid1: Time-based with MAC address (all Python versions)
+    - uuid3: MD5 namespace hash (all Python versions)
+    - uuid4: Random (all Python versions)
+    - uuid5: SHA-1 namespace hash (all Python versions)
+    - uuid6: Reordered time-based (Python 3.14+ or uuid6 package)
+    - uuid7: Unix timestamp-based (Python 3.14+ or uuid6 package)
+    - uuid8: Custom format (Python 3.14+ or uuid6 package)
 
 Usage:
     # At plugin initialization (once)
     install_proxy()
 
     # In freeze_uuid.__enter__
-    token = set_generator(my_patched_uuid4)
+    token = set_generator(my_patched_uuid4, func_name="uuid4")
 
     # In freeze_uuid.__exit__
     reset_generator(token)
@@ -34,83 +43,143 @@ from __future__ import annotations
 
 import threading
 import uuid
-from typing import Callable
+from typing import Any, Callable
 
-# The original uuid.uuid4 function, captured before any patching
-_original_uuid4: Callable[[], uuid.UUID] | None = None
+from pytest_uuid._compat import HAS_UUID6_7_8
 
-# Thread-safe stack of generators, protected by a lock
-# Each freeze_uuid context pushes a generator onto the stack
-# Nested contexts result in multiple entries; innermost is at the end
-_generator_stack: list[Callable[[], uuid.UUID]] = []
+# Type alias for UUID generator functions
+UUIDGenerator = Callable[..., uuid.UUID]
+
+# All supported UUID function names
+UUID_FUNC_NAMES = ("uuid1", "uuid3", "uuid4", "uuid5", "uuid6", "uuid7", "uuid8")
+
+# Functions available in all Python versions (stdlib)
+STDLIB_UUID_FUNCS = ("uuid1", "uuid3", "uuid4", "uuid5")
+
+# Functions that require Python 3.14+ or uuid6 package
+EXTENDED_UUID_FUNCS = ("uuid6", "uuid7", "uuid8")
+
+# Original UUID functions, captured before any patching
+# Key: function name (e.g., "uuid4"), Value: original function
+_originals: dict[str, UUIDGenerator] = {}
+
+# Thread-safe stacks of generators, protected by a lock
+# Key: function name, Value: list of generators (innermost at end)
+_generator_stacks: dict[str, list[UUIDGenerator]] = {
+    name: [] for name in UUID_FUNC_NAMES
+}
 _generator_lock = threading.Lock()
 
 # Track whether the proxy has been installed
 _proxy_installed: bool = False
 
 
-def _proxy_uuid4() -> uuid.UUID:
-    """Permanent proxy that delegates to current generator.
+def _create_proxy(func_name: str) -> Callable[..., uuid.UUID]:
+    """Create a proxy function for a specific UUID function.
 
-    This function replaces uuid.uuid4 at plugin initialization.
-    It checks the generator stack:
-    - If a generator is set (inside a freeze_uuid context), call it
-    - If not set (outside any context), call the original uuid4
+    Args:
+        func_name: The name of the UUID function (e.g., "uuid4").
+
+    Returns:
+        A proxy function that delegates to the current generator or original.
     """
-    generator = None
-    with _generator_lock:
-        if _generator_stack:
-            generator = _generator_stack[-1]
-    if generator is not None:
-        # Call outside lock to avoid holding lock during user code
-        return generator()
-    # Fall back to original uuid4
-    assert _original_uuid4 is not None, "Proxy called before installation"
-    return _original_uuid4()
+
+    def proxy(*args: Any, **kwargs: Any) -> uuid.UUID:
+        generator = None
+        with _generator_lock:
+            stack = _generator_stacks.get(func_name)
+            if stack:
+                generator = stack[-1]
+        if generator is not None:
+            # Call outside lock to avoid holding lock during user code
+            return generator(*args, **kwargs)
+        # Fall back to original function
+        original = _originals.get(func_name)
+        if original is None:
+            raise RuntimeError(
+                f"Proxy for {func_name} called before installation. "
+                f"Ensure pytest-uuid plugin is loaded."
+            )
+        return original(*args, **kwargs)
+
+    # Preserve function metadata for debugging
+    proxy.__name__ = f"_proxy_{func_name}"
+    proxy.__qualname__ = f"_proxy_{func_name}"
+    proxy.__doc__ = f"Proxy for uuid.{func_name}() that enables context-aware mocking."
+
+    return proxy
 
 
 def install_proxy() -> None:
-    """Install the uuid4 proxy.
+    """Install proxies for all supported UUID functions.
 
     This should be called once at plugin initialization (pytest_configure).
-    It replaces uuid.uuid4 with our proxy function.
+    It replaces uuid.uuid1, uuid.uuid3, uuid.uuid4, uuid.uuid5 with proxies,
+    and uuid.uuid6, uuid.uuid7, uuid.uuid8 if available.
 
     The proxy is idempotent - calling multiple times is safe.
     """
-    global _original_uuid4, _proxy_installed
+    global _proxy_installed
 
     if _proxy_installed:
         return
 
-    # Capture the original uuid4 before any patching
-    _original_uuid4 = uuid.uuid4
+    # Install proxies for stdlib functions (always available)
+    for func_name in STDLIB_UUID_FUNCS:
+        original = getattr(uuid, func_name)
+        _originals[func_name] = original
+        setattr(uuid, func_name, _create_proxy(func_name))
 
-    # Install our proxy
-    uuid.uuid4 = _proxy_uuid4  # type: ignore[assignment]
+    # Install proxies for extended functions (Python 3.14+ or uuid6 package)
+    if HAS_UUID6_7_8:
+        for func_name in EXTENDED_UUID_FUNCS:
+            if hasattr(uuid, func_name):
+                # Python 3.14+ - use stdlib
+                original = getattr(uuid, func_name)
+                _originals[func_name] = original
+                setattr(uuid, func_name, _create_proxy(func_name))
+            else:
+                # Python < 3.14 with uuid6 package - import from uuid6
+                from pytest_uuid._compat import uuid6, uuid7, uuid8
+
+                func_map = {"uuid6": uuid6, "uuid7": uuid7, "uuid8": uuid8}
+                original = func_map.get(func_name)
+                if original is not None:
+                    _originals[func_name] = original
+                    # Note: We don't patch uuid6 module itself, just track original
 
     _proxy_installed = True
 
 
 def uninstall_proxy() -> None:
-    """Restore the original uuid.uuid4.
+    """Restore the original UUID functions.
 
     This is primarily for testing the proxy itself.
     In normal usage, the proxy stays installed for the pytest session.
     """
-    global _original_uuid4, _proxy_installed
+    global _proxy_installed
 
     if not _proxy_installed:
         return
 
-    if _original_uuid4 is not None:
-        uuid.uuid4 = _original_uuid4  # type: ignore[assignment]
+    # Restore stdlib functions
+    for func_name in STDLIB_UUID_FUNCS:
+        original = _originals.get(func_name)
+        if original is not None:
+            setattr(uuid, func_name, original)
 
-    _original_uuid4 = None
+    # Restore extended functions (only if they were patched)
+    for func_name in EXTENDED_UUID_FUNCS:
+        if hasattr(uuid, func_name) and func_name in _originals:
+            setattr(uuid, func_name, _originals[func_name])
+
+    _originals.clear()
     _proxy_installed = False
 
-    # Clear the generator stack
+    # Clear all generator stacks
     with _generator_lock:
-        _generator_stack.clear()
+        for stack in _generator_stacks.values():
+            stack.clear()
 
 
 def is_proxy_installed() -> bool:
@@ -118,6 +187,43 @@ def is_proxy_installed() -> bool:
     return _proxy_installed
 
 
+def get_original(func_name: str = "uuid4") -> UUIDGenerator:
+    """Get the original UUID function.
+
+    This is used by generators that need to call the real function
+    (e.g., RandomUUIDGenerator, or when a module is in the ignore list).
+
+    Args:
+        func_name: The UUID function name (default: "uuid4").
+
+    Returns:
+        The original UUID function.
+
+    Raises:
+        RuntimeError: If proxy is not installed.
+        ValueError: If the function name is not supported.
+    """
+    if func_name not in UUID_FUNC_NAMES:
+        raise ValueError(
+            f"Unknown UUID function: {func_name}. "
+            f"Supported: {', '.join(UUID_FUNC_NAMES)}"
+        )
+
+    original = _originals.get(func_name)
+    if original is None:
+        if func_name in EXTENDED_UUID_FUNCS:
+            raise RuntimeError(
+                f"{func_name} requires Python 3.14+ or the 'uuid6' package. "
+                f"Install with: pip install uuid6"
+            )
+        raise RuntimeError(
+            "Proxy not installed. Call install_proxy() first, "
+            "or ensure pytest-uuid plugin is loaded."
+        )
+    return original
+
+
+# Backward compatibility alias
 def get_original_uuid4() -> Callable[[], uuid.UUID]:
     """Get the original uuid.uuid4 function.
 
@@ -127,37 +233,45 @@ def get_original_uuid4() -> Callable[[], uuid.UUID]:
     Raises:
         RuntimeError: If proxy is not installed.
     """
-    if _original_uuid4 is None:
-        raise RuntimeError(
-            "Proxy not installed. Call install_proxy() first, "
-            "or ensure pytest-uuid plugin is loaded."
-        )
-    return _original_uuid4
+    return get_original("uuid4")
 
 
 class GeneratorToken:
     """Token returned by set_generator() for proper stack management."""
 
-    def __init__(self, generator: Callable[[], uuid.UUID]) -> None:
+    def __init__(self, generator: UUIDGenerator, func_name: str = "uuid4") -> None:
         self.generator = generator
+        self.func_name = func_name
 
 
 def set_generator(
-    generator: Callable[[], uuid.UUID],
+    generator: UUIDGenerator,
+    func_name: str = "uuid4",
 ) -> GeneratorToken:
     """Set the current UUID generator for this context.
 
     Args:
-        generator: A callable that returns UUIDs (typically a patched uuid4
-            function with call tracking and generator logic).
+        generator: A callable that returns UUIDs (typically a patched function
+            with call tracking and generator logic).
+        func_name: The UUID function name to set the generator for.
+            Default is "uuid4" for backward compatibility.
 
     Returns:
         A token that can be used to reset the generator later.
         Pass this token to reset_generator() in __exit__.
+
+    Raises:
+        ValueError: If the function name is not supported.
     """
+    if func_name not in UUID_FUNC_NAMES:
+        raise ValueError(
+            f"Unknown UUID function: {func_name}. "
+            f"Supported: {', '.join(UUID_FUNC_NAMES)}"
+        )
+
     with _generator_lock:
-        _generator_stack.append(generator)
-    return GeneratorToken(generator)
+        _generator_stacks[func_name].append(generator)
+    return GeneratorToken(generator, func_name)
 
 
 def reset_generator(token: GeneratorToken) -> None:
@@ -168,20 +282,27 @@ def reset_generator(token: GeneratorToken) -> None:
             This removes the generator from the stack.
     """
     with _generator_lock:
+        stack = _generator_stacks.get(token.func_name)
+        if stack is None:
+            return
         # Remove the generator from the stack
         # Should be at the end if contexts are properly nested
-        if _generator_stack and _generator_stack[-1] is token.generator:
-            _generator_stack.pop()
-        elif token.generator in _generator_stack:
+        if stack and stack[-1] is token.generator:
+            stack.pop()
+        elif token.generator in stack:
             # Handle out-of-order cleanup (shouldn't happen normally)
-            _generator_stack.remove(token.generator)
+            stack.remove(token.generator)
 
 
-def get_current_generator() -> Callable[[], uuid.UUID] | None:
-    """Get the current generator, if any.
+def get_current_generator(func_name: str = "uuid4") -> UUIDGenerator | None:
+    """Get the current generator for a UUID function, if any.
+
+    Args:
+        func_name: The UUID function name (default: "uuid4").
 
     Returns:
         The current generator callable, or None if outside any freeze context.
     """
     with _generator_lock:
-        return _generator_stack[-1] if _generator_stack else None
+        stack = _generator_stacks.get(func_name)
+        return stack[-1] if stack else None

--- a/src/pytest_uuid/_tracking.py
+++ b/src/pytest_uuid/_tracking.py
@@ -2,6 +2,10 @@
 
 This module provides shared functionality for tracking uuid4() calls
 across UUIDMocker, UUIDSpy, and UUIDFreezer classes.
+
+Thread Safety:
+    All tracking operations are protected by a lock, making this class
+    thread-safe for concurrent UUID calls from multiple threads.
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ import gc
 import hashlib
 import inspect
 import sys
+import threading
 import uuid
 from types import FrameType, FunctionType
 
@@ -129,18 +134,18 @@ class CallTrackingMixin:
         self._call_count: int = 0
         self._generated_uuids: list[uuid.UUID] = []
         self._calls: list[UUIDCall] = []
+        self._tracking_lock: threading.Lock = threading.Lock()
 
-    Note:
-        This class is NOT thread-safe. The tracking methods modify shared
-        state without synchronization. This is acceptable for typical pytest
-        usage where tests run sequentially, but concurrent uuid4() calls
-        from multiple threads may result in race conditions. If thread-safe
-        tracking is needed, consider using threading.Lock in your code.
+    Thread Safety:
+        All tracking operations are protected by a lock, making this class
+        thread-safe for concurrent UUID calls from multiple threads. The lock
+        is per-instance, so different mocker instances can track concurrently.
     """
 
     _call_count: int
     _generated_uuids: list[uuid.UUID]
     _calls: list[UUIDCall]
+    _tracking_lock: threading.Lock
 
     def _record_call(
         self,
@@ -153,7 +158,7 @@ class CallTrackingMixin:
         caller_qualname: str | None = None,
         uuid_version: int = 4,
     ) -> None:
-        """Record a UUID call for tracking.
+        """Record a UUID call for tracking (thread-safe).
 
         Args:
             result: The UUID that was generated.
@@ -165,75 +170,85 @@ class CallTrackingMixin:
             caller_qualname: The qualified name of the function (e.g., "MyClass.method").
             uuid_version: The UUID version (1, 3, 4, 5, 6, 7, or 8). Defaults to 4.
         """
-        self._call_count += 1
-        self._generated_uuids.append(result)
-        self._calls.append(
-            UUIDCall(
-                uuid=result,
-                was_mocked=was_mocked,
-                uuid_version=uuid_version,
-                caller_module=caller_module,
-                caller_file=caller_file,
-                caller_line=caller_line,
-                caller_function=caller_function,
-                caller_qualname=caller_qualname,
-            )
+        # Create UUIDCall outside the lock to minimize lock hold time
+        call = UUIDCall(
+            uuid=result,
+            was_mocked=was_mocked,
+            uuid_version=uuid_version,
+            caller_module=caller_module,
+            caller_file=caller_file,
+            caller_line=caller_line,
+            caller_function=caller_function,
+            caller_qualname=caller_qualname,
         )
+        with self._tracking_lock:
+            self._call_count += 1
+            self._generated_uuids.append(result)
+            self._calls.append(call)
 
     def _reset_tracking(self) -> None:
-        """Reset all tracking data to initial state."""
-        self._call_count = 0
-        self._generated_uuids.clear()
-        self._calls.clear()
+        """Reset all tracking data to initial state (thread-safe)."""
+        with self._tracking_lock:
+            self._call_count = 0
+            self._generated_uuids.clear()
+            self._calls.clear()
 
     @property
     def call_count(self) -> int:
-        """Get the number of times uuid4 was called."""
-        return self._call_count
+        """Get the number of times uuid4 was called (thread-safe)."""
+        with self._tracking_lock:
+            return self._call_count
 
     @property
     def generated_uuids(self) -> list[uuid.UUID]:
-        """Get a list of all UUIDs that have been generated.
+        """Get a list of all UUIDs that have been generated (thread-safe snapshot).
 
-        Returns a copy to prevent external modification.
+        Returns a copy to prevent external modification and ensure thread safety.
         """
-        return list(self._generated_uuids)
+        with self._tracking_lock:
+            return list(self._generated_uuids)
 
     @property
     def last_uuid(self) -> uuid.UUID | None:
-        """Get the most recently generated UUID, or None if none generated."""
-        return self._generated_uuids[-1] if self._generated_uuids else None
+        """Get the most recently generated UUID, or None if none generated (thread-safe)."""
+        with self._tracking_lock:
+            return self._generated_uuids[-1] if self._generated_uuids else None
 
     @property
     def calls(self) -> list[UUIDCall]:
-        """Get detailed metadata for all uuid4 calls.
+        """Get detailed metadata for all uuid4 calls (thread-safe snapshot).
 
-        Returns a copy to prevent external modification.
+        Returns a copy to prevent external modification and ensure thread safety.
         """
-        return list(self._calls)
+        with self._tracking_lock:
+            return list(self._calls)
 
     @property
     def mocked_calls(self) -> list[UUIDCall]:
-        """Get only the calls that returned mocked UUIDs."""
-        return [c for c in self._calls if c.was_mocked]
+        """Get only the calls that returned mocked UUIDs (thread-safe)."""
+        with self._tracking_lock:
+            return [c for c in self._calls if c.was_mocked]
 
     @property
     def real_calls(self) -> list[UUIDCall]:
-        """Get only the calls that returned real UUIDs (e.g., spy mode)."""
-        return [c for c in self._calls if not c.was_mocked]
+        """Get only the calls that returned real UUIDs (e.g., spy mode) (thread-safe)."""
+        with self._tracking_lock:
+            return [c for c in self._calls if not c.was_mocked]
 
     @property
     def mocked_count(self) -> int:
-        """Get the number of calls that returned mocked UUIDs."""
-        return sum(1 for c in self._calls if c.was_mocked)
+        """Get the number of calls that returned mocked UUIDs (thread-safe)."""
+        with self._tracking_lock:
+            return sum(1 for c in self._calls if c.was_mocked)
 
     @property
     def real_count(self) -> int:
-        """Get the number of calls that returned real UUIDs."""
-        return sum(1 for c in self._calls if not c.was_mocked)
+        """Get the number of calls that returned real UUIDs (thread-safe)."""
+        with self._tracking_lock:
+            return sum(1 for c in self._calls if not c.was_mocked)
 
     def calls_from(self, module_prefix: str) -> list[UUIDCall]:
-        """Get calls from modules matching the given prefix.
+        """Get calls from modules matching the given prefix (thread-safe).
 
         Args:
             module_prefix: Module name prefix to filter by (e.g., "myapp.models").
@@ -241,8 +256,9 @@ class CallTrackingMixin:
         Returns:
             List of UUIDCall records from matching modules.
         """
-        return [
-            c
-            for c in self._calls
-            if c.caller_module and c.caller_module.startswith(module_prefix)
-        ]
+        with self._tracking_lock:
+            return [
+                c
+                for c in self._calls
+                if c.caller_module and c.caller_module.startswith(module_prefix)
+            ]

--- a/src/pytest_uuid/_tracking.py
+++ b/src/pytest_uuid/_tracking.py
@@ -151,8 +151,9 @@ class CallTrackingMixin:
         caller_line: int | None = None,
         caller_function: str | None = None,
         caller_qualname: str | None = None,
+        uuid_version: int = 4,
     ) -> None:
-        """Record a uuid4 call for tracking.
+        """Record a UUID call for tracking.
 
         Args:
             result: The UUID that was generated.
@@ -162,6 +163,7 @@ class CallTrackingMixin:
             caller_line: The line number where the call originated.
             caller_function: The function name where the call originated.
             caller_qualname: The qualified name of the function (e.g., "MyClass.method").
+            uuid_version: The UUID version (1, 3, 4, 5, 6, 7, or 8). Defaults to 4.
         """
         self._call_count += 1
         self._generated_uuids.append(result)
@@ -169,6 +171,7 @@ class CallTrackingMixin:
             UUIDCall(
                 uuid=result,
                 was_mocked=was_mocked,
+                uuid_version=uuid_version,
                 caller_module=caller_module,
                 caller_file=caller_file,
                 caller_line=caller_line,

--- a/src/pytest_uuid/api.py
+++ b/src/pytest_uuid/api.py
@@ -236,14 +236,15 @@ class UUIDFreezer(CallTrackingMixin):
         """Create the appropriate random generator for the UUID version."""
         if self._uuid_version == "uuid1":
             return RandomUUID1Generator(node=self._node, clock_seq=self._clock_seq)
+        if self._uuid_version == "uuid4":
+            return RandomUUIDGenerator()
         if self._uuid_version == "uuid6":
             return RandomUUID6Generator(node=self._node, clock_seq=self._clock_seq)
         if self._uuid_version == "uuid7":
             return RandomUUID7Generator()
         if self._uuid_version == "uuid8":
             return RandomUUID8Generator()
-        # uuid4 or fallback
-        return RandomUUIDGenerator()
+        raise ValueError(f"Unknown UUID version: {self._uuid_version}")
 
     def _create_patched_function(self) -> Callable[..., uuid.UUID]:
         """Create the patched UUID function with ignore list and call tracking."""

--- a/src/pytest_uuid/api.py
+++ b/src/pytest_uuid/api.py
@@ -45,7 +45,7 @@ from typing import TYPE_CHECKING, Literal, overload
 
 from pytest_uuid._proxy import (
     GeneratorToken,
-    get_original_uuid4,
+    get_original,
     reset_generator,
     set_generator,
 )
@@ -57,11 +57,15 @@ from pytest_uuid._tracking import (
 from pytest_uuid.config import get_config
 from pytest_uuid.generators import (
     ExhaustionBehavior,
+    RandomUUID1Generator,
+    RandomUUID6Generator,
+    RandomUUID7Generator,
+    RandomUUID8Generator,
     RandomUUIDGenerator,
-    SeededUUIDGenerator,
     SequenceUUIDGenerator,
     StaticUUIDGenerator,
     UUIDGenerator,
+    get_seeded_generator,
     parse_uuid,
     parse_uuids,
 )
@@ -92,20 +96,21 @@ def _should_ignore_frame(frame: object, ignore_list: tuple[str, ...]) -> bool:
 
 
 class UUIDFreezer(CallTrackingMixin):
-    """Context manager and decorator for freezing uuid.uuid4() calls.
+    """Context manager and decorator for freezing UUID function calls.
 
     This class provides fine-grained control over UUID generation during tests.
     It can be used as a decorator or context manager. Most users should use
-    the freeze_uuid() factory function instead of instantiating this directly.
+    the freeze_uuid4(), freeze_uuid7(), etc. factory functions instead of
+    instantiating this directly.
 
     Usage Patterns:
-        - As decorator: @freeze_uuid("uuid") applies to entire function
-        - As context manager: with freeze_uuid("uuid") as f: ... for scoped control
-        - On classes: @freeze_uuid("uuid") wraps all test_* methods
+        - As decorator: @freeze_uuid4("uuid") applies to entire function
+        - As context manager: with freeze_uuid4("uuid") as f: ... for scoped control
+        - On classes: @freeze_uuid4("uuid") wraps all test_* methods
 
     Call Tracking:
-        While active, tracks all uuid4() calls via inherited properties:
-        - call_count: Total number of uuid4() calls
+        While active, tracks all calls to the target UUID function via inherited properties:
+        - call_count: Total number of calls
         - generated_uuids: List of all UUIDs returned
         - last_uuid: Most recent UUID returned
         - calls: List of UUIDCall records with metadata
@@ -113,7 +118,7 @@ class UUIDFreezer(CallTrackingMixin):
 
     Example:
         # Context manager with call inspection
-        with freeze_uuid(seed=42) as freezer:
+        with freeze_uuid4(seed=42) as freezer:
             first = uuid.uuid4()
             second = uuid.uuid4()
 
@@ -127,16 +132,21 @@ class UUIDFreezer(CallTrackingMixin):
         self,
         uuids: str | uuid.UUID | Sequence[str | uuid.UUID] | None = None,
         *,
+        uuid_version: str = "uuid4",
         seed: int | random.Random | Literal["node"] | None = None,
         on_exhausted: ExhaustionBehavior | str | None = None,
         ignore: Sequence[str] | None = None,
         ignore_defaults: bool = True,
         node_id: str | None = None,
+        node: int | None = None,
+        clock_seq: int | None = None,
     ) -> None:
         """Initialize the UUID freezer.
 
         Args:
             uuids: Static UUID(s) to return. Can be a single UUID or a sequence.
+            uuid_version: The UUID function to freeze ("uuid1", "uuid4", "uuid6",
+                "uuid7", "uuid8"). Default is "uuid4".
             seed: Seed for reproducible UUID generation. Can be:
                 - int: Create a fresh Random instance with this seed
                 - random.Random: Use this Random instance directly
@@ -146,10 +156,15 @@ class UUIDFreezer(CallTrackingMixin):
             ignore_defaults: Whether to include default ignore list (e.g., botocore).
                 Set to False to mock all modules including those in DEFAULT_IGNORE_PACKAGES.
             node_id: The pytest node ID (required when seed="node").
+            node: Fixed 48-bit node (MAC address) for uuid1/uuid6 seeded generation.
+            clock_seq: Fixed 14-bit clock sequence for uuid1/uuid6 seeded generation.
         """
         self._uuids = uuids
+        self._uuid_version = uuid_version
         self._seed = seed
         self._node_id = node_id
+        self._node = node
+        self._clock_seq = clock_seq
         self._ignore_extra = tuple(ignore) if ignore else ()
 
         config = get_config()
@@ -181,15 +196,24 @@ class UUIDFreezer(CallTrackingMixin):
         if self._seed is not None:
             if self._seed == "node":
                 if self._node_id is None:
+                    marker_name = f"freeze_{self._uuid_version}"
                     raise ValueError(
-                        "seed='node' requires node_id to be provided. "
-                        "Use @pytest.mark.freeze_uuid(seed='node') or pass node_id explicitly."
+                        f"seed='node' requires node_id to be provided. "
+                        f"Use @pytest.mark.{marker_name}(seed='node') or pass node_id explicitly."
                     )
                 actual_seed = _get_node_seed(self._node_id)
-                return SeededUUIDGenerator(actual_seed)
-            if isinstance(self._seed, random.Random):
-                return SeededUUIDGenerator(self._seed)
-            return SeededUUIDGenerator(self._seed)
+            elif isinstance(self._seed, random.Random):
+                actual_seed = self._seed
+            else:
+                actual_seed = self._seed
+
+            # Use version-appropriate seeded generator
+            return get_seeded_generator(
+                self._uuid_version,
+                actual_seed,
+                node=self._node,
+                clock_seq=self._clock_seq,
+            )
 
         if self._uuids is not None:
             if isinstance(self._uuids, (str, uuid.UUID)):
@@ -205,19 +229,35 @@ class UUIDFreezer(CallTrackingMixin):
                 on_exhausted=self._on_exhausted,
             )
 
-        # Default: random UUIDs (but we still need to patch for ignore list support)
+        # Default: random UUIDs - use version-appropriate random generator
+        return self._create_random_generator()
+
+    def _create_random_generator(self) -> UUIDGenerator:
+        """Create the appropriate random generator for the UUID version."""
+        if self._uuid_version == "uuid1":
+            return RandomUUID1Generator(node=self._node, clock_seq=self._clock_seq)
+        if self._uuid_version == "uuid6":
+            return RandomUUID6Generator(node=self._node, clock_seq=self._clock_seq)
+        if self._uuid_version == "uuid7":
+            return RandomUUID7Generator()
+        if self._uuid_version == "uuid8":
+            return RandomUUID8Generator()
+        # uuid4 or fallback
         return RandomUUIDGenerator()
 
-    def _create_patched_uuid4(self) -> Callable[[], uuid.UUID]:
-        """Create the patched uuid4 function with ignore list and call tracking."""
+    def _create_patched_function(self) -> Callable[..., uuid.UUID]:
+        """Create the patched UUID function with ignore list and call tracking."""
         generator = self._generator
         ignore_list = self._ignore_list
         freezer = self  # Capture self for tracking
+        uuid_version = self._uuid_version
 
         if not ignore_list:
-
-            def patched_uuid4() -> uuid.UUID:
-                # skip_frames=3: _get_caller_info -> patched_uuid4 -> _proxy_uuid4 -> caller
+            # Accept *args, **kwargs for compatibility with uuid1/uuid6 signatures
+            def patched_uuid_func(
+                *args: object, **kwargs: object  # noqa: ARG001
+            ) -> uuid.UUID:
+                # skip_frames=3: _get_caller_info -> patched_uuid_func -> _proxy_uuidX -> caller
                 (
                     caller_module,
                     caller_file,
@@ -237,10 +277,10 @@ class UUIDFreezer(CallTrackingMixin):
                 )
                 return result
 
-            return patched_uuid4
+            return patched_uuid_func
 
-        def patched_uuid4_with_ignore() -> uuid.UUID:
-            # skip_frames=3: _get_caller_info -> patched_uuid4_with_ignore -> _proxy_uuid4 -> caller
+        def patched_uuid_func_with_ignore(*args: object, **kwargs: object) -> uuid.UUID:
+            # skip_frames=3: _get_caller_info -> patched_uuid_func_with_ignore -> _proxy_uuidX -> caller
             (
                 caller_module,
                 caller_file,
@@ -252,7 +292,7 @@ class UUIDFreezer(CallTrackingMixin):
             # Walk up the call stack to check for ignored modules
             frame = inspect.currentframe()
             try:
-                # Skip only this frame (patched_uuid4_with_ignore)
+                # Skip only this frame (patched_uuid_func_with_ignore)
                 # We want to check the caller's frame and all frames above it
                 if frame is not None:
                     frame = frame.f_back
@@ -260,7 +300,7 @@ class UUIDFreezer(CallTrackingMixin):
                 # Check if any caller should be ignored
                 while frame is not None:
                     if _should_ignore_frame(frame, ignore_list):
-                        result = get_original_uuid4()()
+                        result = get_original(uuid_version)(*args, **kwargs)
                         freezer._record_call(
                             result,
                             was_mocked=False,
@@ -287,22 +327,22 @@ class UUIDFreezer(CallTrackingMixin):
             )
             return result
 
-        return patched_uuid4_with_ignore
+        return patched_uuid_func_with_ignore
 
     def __enter__(self) -> UUIDFreezer:
-        """Start freezing uuid.uuid4().
+        """Start freezing the target UUID function.
 
         This method:
         1. Creates the UUID generator based on configuration
-        2. Creates the patched uuid4 function with call tracking
+        2. Creates the patched UUID function with call tracking
         3. Sets the generator in the proxy's context variable
 
-        The proxy approach means any code that captured uuid4 (including
-        Pydantic default_factory) will automatically use our generator.
+        The proxy approach means any code that captured the UUID function
+        (including Pydantic default_factory) will automatically use our generator.
         """
         self._generator = self._create_generator()
-        patched = self._create_patched_uuid4()
-        self._token = set_generator(patched)
+        patched = self._create_patched_function()
+        self._token = set_generator(patched, func_name=self._uuid_version)
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -351,22 +391,28 @@ class UUIDFreezer(CallTrackingMixin):
         """Wrap a single method with a fresh freeze context."""
         # Capture the freezer config to create fresh instances per call
         uuids = self._uuids
+        uuid_version = self._uuid_version
         seed = self._seed
         on_exhausted = self._on_exhausted
         ignore_extra = self._ignore_extra
         ignore_defaults = self._ignore_defaults
         node_id = self._node_id
+        node = self._node
+        clock_seq = self._clock_seq
 
         @functools.wraps(method)
         def wrapper(*args: object, **kwargs: object) -> object:
             # Create a fresh freezer for each method call
             freezer = UUIDFreezer(
                 uuids=uuids,
+                uuid_version=uuid_version,
                 seed=seed,
                 on_exhausted=on_exhausted,
                 ignore=ignore_extra if ignore_extra else None,
                 ignore_defaults=ignore_defaults,
                 node_id=node_id,
+                node=node,
+                clock_seq=clock_seq,
             )
             with freezer:
                 return method(*args, **kwargs)
@@ -377,6 +423,11 @@ class UUIDFreezer(CallTrackingMixin):
     def generator(self) -> UUIDGenerator | None:
         """Get the current generator (only available while frozen)."""
         return self._generator
+
+    @property
+    def uuid_version(self) -> str:
+        """The UUID version being frozen (e.g., "uuid4", "uuid7")."""
+        return self._uuid_version
 
     @property
     def seed(self) -> int | None:
@@ -390,8 +441,9 @@ class UUIDFreezer(CallTrackingMixin):
         - A random.Random instance was passed directly (BYOP mode)
         - The freezer is not currently active
         """
-        if isinstance(self._generator, SeededUUIDGenerator):
-            return self._generator.seed
+        # Check if the generator has a seed property (all seeded generators do)
+        if self._generator is not None and hasattr(self._generator, "seed"):
+            return self._generator.seed  # type: ignore[union-attr]
         return None
 
     def reset(self) -> None:
@@ -401,7 +453,450 @@ class UUIDFreezer(CallTrackingMixin):
         self._reset_tracking()
 
 
-# Convenience function for creating freezers
+# =============================================================================
+# Version-specific freeze functions
+# =============================================================================
+
+
+# freeze_uuid4 - for uuid.uuid4()
+@overload
+def freeze_uuid4(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID],
+    *,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid4(
+    uuids: None = None,
+    *,
+    seed: int | random.Random | Literal["node"],
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid4(
+    uuids: None = None,
+    *,
+    seed: None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+def freeze_uuid4(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID] | None = None,
+    *,
+    seed: int | random.Random | Literal["node"] | None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer:
+    """Create a freezer for uuid.uuid4() calls.
+
+    This function returns a UUIDFreezer that can be used as a decorator
+    or context manager to control uuid.uuid4() calls within its scope.
+
+    Args:
+        uuids: Static UUID(s) to return. Can be:
+            - A single UUID string or object (always returns this UUID)
+            - A sequence of UUIDs (cycles through or raises when exhausted)
+        seed: Seed for reproducible UUID generation. Can be:
+            - int: Create a fresh Random instance with this seed
+            - random.Random: Use this Random instance directly (BYOP)
+            - "node": Derive seed from pytest node ID (use with marker)
+        on_exhausted: Behavior when a UUID sequence is exhausted:
+            - "cycle": Loop back to the start (default)
+            - "random": Fall back to random UUIDs
+            - "raise": Raise UUIDsExhaustedError
+        ignore: Module prefixes that should continue using real uuid4().
+        ignore_defaults: Whether to include default ignore list (e.g., botocore).
+        node_id: The pytest node ID (required when seed="node").
+
+    Returns:
+        A UUIDFreezer that can be used as a decorator or context manager.
+
+    Examples:
+        # As a decorator with a static UUID
+        @freeze_uuid4("12345678-1234-4678-8234-567812345678")
+        def test_static():
+            assert uuid.uuid4() == UUID("12345678-...")
+
+        # As a decorator with a seed
+        @freeze_uuid4(seed=42)
+        def test_seeded():
+            ...
+
+        # As a context manager
+        with freeze_uuid4("...") as freezer:
+            result = uuid.uuid4()
+            assert freezer.call_count == 1
+    """
+    return UUIDFreezer(
+        uuids=uuids,
+        uuid_version="uuid4",
+        seed=seed,
+        on_exhausted=on_exhausted,
+        ignore=ignore,
+        ignore_defaults=ignore_defaults,
+        node_id=node_id,
+    )
+
+
+# freeze_uuid1 - for uuid.uuid1()
+@overload
+def freeze_uuid1(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID],
+    *,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid1(
+    uuids: None = None,
+    *,
+    seed: int | random.Random | Literal["node"],
+    node: int | None = None,
+    clock_seq: int | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid1(
+    uuids: None = None,
+    *,
+    seed: None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+def freeze_uuid1(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID] | None = None,
+    *,
+    seed: int | random.Random | Literal["node"] | None = None,
+    node: int | None = None,
+    clock_seq: int | None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer:
+    """Create a freezer for uuid.uuid1() calls.
+
+    This function returns a UUIDFreezer that can be used as a decorator
+    or context manager to control uuid.uuid1() calls within its scope.
+
+    UUID v1 is time-based with MAC address. For seeded generation, the
+    time fields are generated from the random source for reproducibility.
+
+    Args:
+        uuids: Static UUID(s) to return.
+        seed: Seed for reproducible UUID generation.
+        node: Fixed 48-bit node (MAC address) for seeded generation.
+        clock_seq: Fixed 14-bit clock sequence for seeded generation.
+        on_exhausted: Behavior when a UUID sequence is exhausted.
+        ignore: Module prefixes that should continue using real uuid1().
+        ignore_defaults: Whether to include default ignore list.
+        node_id: The pytest node ID (required when seed="node").
+
+    Returns:
+        A UUIDFreezer that can be used as a decorator or context manager.
+
+    Examples:
+        @freeze_uuid1("12345678-1234-1234-8234-567812345678")
+        def test_static():
+            assert uuid.uuid1() == UUID("12345678-...")
+
+        @freeze_uuid1(seed=42, node=0x123456789abc)
+        def test_seeded_with_fixed_node():
+            ...
+    """
+    return UUIDFreezer(
+        uuids=uuids,
+        uuid_version="uuid1",
+        seed=seed,
+        on_exhausted=on_exhausted,
+        ignore=ignore,
+        ignore_defaults=ignore_defaults,
+        node_id=node_id,
+        node=node,
+        clock_seq=clock_seq,
+    )
+
+
+# freeze_uuid6 - for uuid.uuid6()
+@overload
+def freeze_uuid6(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID],
+    *,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid6(
+    uuids: None = None,
+    *,
+    seed: int | random.Random | Literal["node"],
+    node: int | None = None,
+    clock_seq: int | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid6(
+    uuids: None = None,
+    *,
+    seed: None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+def freeze_uuid6(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID] | None = None,
+    *,
+    seed: int | random.Random | Literal["node"] | None = None,
+    node: int | None = None,
+    clock_seq: int | None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer:
+    """Create a freezer for uuid.uuid6() calls.
+
+    This function returns a UUIDFreezer that can be used as a decorator
+    or context manager to control uuid.uuid6() calls within its scope.
+
+    UUID v6 is a reordered version of UUID v1 optimized for database indexing.
+    Requires Python 3.14+ or the uuid6 backport package.
+
+    Args:
+        uuids: Static UUID(s) to return.
+        seed: Seed for reproducible UUID generation.
+        node: Fixed 48-bit node (MAC address) for seeded generation.
+        clock_seq: Fixed 14-bit clock sequence for seeded generation.
+        on_exhausted: Behavior when a UUID sequence is exhausted.
+        ignore: Module prefixes that should continue using real uuid6().
+        ignore_defaults: Whether to include default ignore list.
+        node_id: The pytest node ID (required when seed="node").
+
+    Returns:
+        A UUIDFreezer that can be used as a decorator or context manager.
+
+    Examples:
+        @freeze_uuid6("12345678-1234-6234-8234-567812345678")
+        def test_static():
+            assert uuid.uuid6() == UUID("12345678-...")
+
+        @freeze_uuid6(seed=42)
+        def test_seeded():
+            ...
+    """
+    return UUIDFreezer(
+        uuids=uuids,
+        uuid_version="uuid6",
+        seed=seed,
+        on_exhausted=on_exhausted,
+        ignore=ignore,
+        ignore_defaults=ignore_defaults,
+        node_id=node_id,
+        node=node,
+        clock_seq=clock_seq,
+    )
+
+
+# freeze_uuid7 - for uuid.uuid7()
+@overload
+def freeze_uuid7(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID],
+    *,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid7(
+    uuids: None = None,
+    *,
+    seed: int | random.Random | Literal["node"],
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid7(
+    uuids: None = None,
+    *,
+    seed: None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+def freeze_uuid7(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID] | None = None,
+    *,
+    seed: int | random.Random | Literal["node"] | None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer:
+    """Create a freezer for uuid.uuid7() calls.
+
+    This function returns a UUIDFreezer that can be used as a decorator
+    or context manager to control uuid.uuid7() calls within its scope.
+
+    UUID v7 uses Unix timestamp (milliseconds) with random data.
+    Requires Python 3.14+ or the uuid6 backport package.
+
+    Args:
+        uuids: Static UUID(s) to return.
+        seed: Seed for reproducible UUID generation.
+        on_exhausted: Behavior when a UUID sequence is exhausted.
+        ignore: Module prefixes that should continue using real uuid7().
+        ignore_defaults: Whether to include default ignore list.
+        node_id: The pytest node ID (required when seed="node").
+
+    Returns:
+        A UUIDFreezer that can be used as a decorator or context manager.
+
+    Examples:
+        @freeze_uuid7("01234567-89ab-7def-8123-456789abcdef")
+        def test_static():
+            assert uuid.uuid7() == UUID("01234567-...")
+
+        @freeze_uuid7(seed=42)
+        def test_seeded():
+            ...
+    """
+    return UUIDFreezer(
+        uuids=uuids,
+        uuid_version="uuid7",
+        seed=seed,
+        on_exhausted=on_exhausted,
+        ignore=ignore,
+        ignore_defaults=ignore_defaults,
+        node_id=node_id,
+    )
+
+
+# freeze_uuid8 - for uuid.uuid8()
+@overload
+def freeze_uuid8(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID],
+    *,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid8(
+    uuids: None = None,
+    *,
+    seed: int | random.Random | Literal["node"],
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer: ...
+
+
+@overload
+def freeze_uuid8(
+    uuids: None = None,
+    *,
+    seed: None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+) -> UUIDFreezer: ...
+
+
+def freeze_uuid8(
+    uuids: str | uuid.UUID | Sequence[str | uuid.UUID] | None = None,
+    *,
+    seed: int | random.Random | Literal["node"] | None = None,
+    on_exhausted: ExhaustionBehavior | str | None = None,
+    ignore: Sequence[str] | None = None,
+    ignore_defaults: bool = True,
+    node_id: str | None = None,
+) -> UUIDFreezer:
+    """Create a freezer for uuid.uuid8() calls.
+
+    This function returns a UUIDFreezer that can be used as a decorator
+    or context manager to control uuid.uuid8() calls within its scope.
+
+    UUID v8 provides a format for experimental or vendor-specific UUIDs.
+    Requires Python 3.14+ or the uuid6 backport package.
+
+    Args:
+        uuids: Static UUID(s) to return.
+        seed: Seed for reproducible UUID generation.
+        on_exhausted: Behavior when a UUID sequence is exhausted.
+        ignore: Module prefixes that should continue using real uuid8().
+        ignore_defaults: Whether to include default ignore list.
+        node_id: The pytest node ID (required when seed="node").
+
+    Returns:
+        A UUIDFreezer that can be used as a decorator or context manager.
+
+    Examples:
+        @freeze_uuid8("12345678-1234-8234-8234-567812345678")
+        def test_static():
+            assert uuid.uuid8() == UUID("12345678-...")
+
+        @freeze_uuid8(seed=42)
+        def test_seeded():
+            ...
+    """
+    return UUIDFreezer(
+        uuids=uuids,
+        uuid_version="uuid8",
+        seed=seed,
+        on_exhausted=on_exhausted,
+        ignore=ignore,
+        ignore_defaults=ignore_defaults,
+        node_id=node_id,
+    )
+
+
+# =============================================================================
+# Backward compatibility alias
+# =============================================================================
+
+
+# Convenience function for creating freezers (backward compatible alias)
 @overload
 def freeze_uuid(
     uuids: str | uuid.UUID | Sequence[str | uuid.UUID],
@@ -443,7 +938,11 @@ def freeze_uuid(
     ignore_defaults: bool = True,
     node_id: str | None = None,
 ) -> UUIDFreezer:
-    """Create a UUID freezer for use as a decorator or context manager.
+    """Create a UUID freezer for uuid.uuid4() calls.
+
+    .. deprecated::
+        Use freeze_uuid4() instead. This function is provided for backward
+        compatibility and is an alias to freeze_uuid4().
 
     This function returns a UUIDFreezer that can be used to control
     uuid.uuid4() calls within its scope.
@@ -496,6 +995,7 @@ def freeze_uuid(
     """
     return UUIDFreezer(
         uuids=uuids,
+        uuid_version="uuid4",
         seed=seed,
         on_exhausted=on_exhausted,
         ignore=ignore,

--- a/src/pytest_uuid/api.py
+++ b/src/pytest_uuid/api.py
@@ -79,6 +79,16 @@ from pytest_uuid.types import UUIDCall
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+__all__ = [
+    "UUIDFreezer",
+    "freeze_uuid",
+    "freeze_uuid1",
+    "freeze_uuid4",
+    "freeze_uuid6",
+    "freeze_uuid7",
+    "freeze_uuid8",
+]
+
 
 def _should_ignore_frame(frame: object, ignore_list: tuple[str, ...]) -> bool:
     """Check if a frame's module should be ignored.

--- a/src/pytest_uuid/api.py
+++ b/src/pytest_uuid/api.py
@@ -21,6 +21,10 @@ Thread Safety:
     should only be entered/exited from a single thread (don't share a context manager
     across threads). For multi-threaded tests, each thread should use its own freezer.
 
+    Note that call tracking (call_count, generated_uuids, calls) is NOT thread-safe.
+    If multiple threads generate UUIDs simultaneously, tracking counts may be inaccurate.
+    This is fine for most use cases where you only care about UUID values, not counts.
+
 Example:
     # As a decorator
     @freeze_uuid("12345678-1234-4678-8234-567812345678")

--- a/src/pytest_uuid/generators.py
+++ b/src/pytest_uuid/generators.py
@@ -274,12 +274,95 @@ class RandomUUIDGenerator(UUIDGenerator):
     """
 
     def __init__(self) -> None:
-        pass  # No state needed - uses get_original_uuid4() at call time
+        pass  # No state needed - uses get_original() at call time
 
     def __call__(self) -> uuid.UUID:
-        from pytest_uuid._proxy import get_original_uuid4
+        from pytest_uuid._proxy import get_original
 
-        return get_original_uuid4()()
+        return get_original("uuid4")()
+
+    def reset(self) -> None:
+        pass  # No state to reset
+
+
+class RandomUUID1Generator(UUIDGenerator):
+    """Generator that produces UUIDs by delegating to uuid.uuid1().
+
+    Used internally when no specific mocking is configured but the patching
+    infrastructure is still needed. Supports optional node and clock_seq
+    parameters.
+
+    Args:
+        node: The hardware address (48-bit integer). If None, uses system MAC.
+        clock_seq: The clock sequence (14-bit integer). If None, uses random.
+    """
+
+    def __init__(
+        self,
+        node: int | None = None,
+        clock_seq: int | None = None,
+    ) -> None:
+        self._node = node
+        self._clock_seq = clock_seq
+
+    def __call__(self) -> uuid.UUID:
+        from pytest_uuid._proxy import get_original
+
+        return get_original("uuid1")(node=self._node, clock_seq=self._clock_seq)
+
+    def reset(self) -> None:
+        pass  # No state to reset
+
+
+class RandomUUID6Generator(UUIDGenerator):
+    """Generator that produces UUIDs by delegating to uuid.uuid6().
+
+    Used internally when no specific mocking is configured. Requires
+    Python 3.14+ or the uuid6 backport package.
+
+    Args:
+        node: The hardware address (48-bit integer). If None, uses system MAC.
+        clock_seq: The clock sequence (14-bit integer). If None, uses random.
+    """
+
+    def __init__(
+        self,
+        node: int | None = None,
+        clock_seq: int | None = None,
+    ) -> None:
+        self._node = node
+        self._clock_seq = clock_seq
+
+    def __call__(self) -> uuid.UUID:
+        from pytest_uuid._compat import require_uuid6_7_8
+        from pytest_uuid._proxy import get_original
+
+        require_uuid6_7_8("uuid6")
+        return get_original("uuid6")(node=self._node, clock_seq=self._clock_seq)
+
+    def reset(self) -> None:
+        pass  # No state to reset
+
+
+class RandomUUID7Generator(UUIDGenerator):
+    """Generator that produces UUIDs by delegating to uuid.uuid7().
+
+    Used internally when no specific mocking is configured. Requires
+    Python 3.14+ or the uuid6 backport package.
+
+    uuid7() uses Unix timestamp (milliseconds) with a monotonic counter
+    for sub-millisecond ordering.
+    """
+
+    def __init__(self) -> None:
+        pass  # No configuration - uuid7 takes no parameters
+
+    def __call__(self) -> uuid.UUID:
+        from pytest_uuid._compat import require_uuid6_7_8
+        from pytest_uuid._proxy import get_original
+
+        require_uuid6_7_8("uuid7")
+        return get_original("uuid7")()
 
     def reset(self) -> None:
         pass  # No state to reset

--- a/src/pytest_uuid/generators.py
+++ b/src/pytest_uuid/generators.py
@@ -423,8 +423,8 @@ def generate_uuid1_from_random(
     # Generate clock_seq: 14 bits (2 bits for variant)
     clock_seq_value = rng.getrandbits(14) if clock_seq is None else clock_seq & 0x3FFF
 
-    # Generate node: 48 bits (MAC address)
-    node_value = rng.getrandbits(48) if node is None else node
+    # Generate node: 48 bits (MAC address), mask to ensure valid range
+    node_value = rng.getrandbits(48) if node is None else node & 0xFFFFFFFFFFFF
 
     # Construct UUID fields with version and variant
     # time_hi_version: 4 bits version (0001 for v1) + 12 bits time_hi
@@ -473,8 +473,8 @@ def generate_uuid6_from_random(
     # Generate clock_seq: 14 bits
     clock_seq_value = rng.getrandbits(14) if clock_seq is None else clock_seq & 0x3FFF
 
-    # Generate node: 48 bits
-    node_value = rng.getrandbits(48) if node is None else node
+    # Generate node: 48 bits, mask to ensure valid range
+    node_value = rng.getrandbits(48) if node is None else node & 0xFFFFFFFFFFFF
 
     # Construct the 128-bit UUID
     # Format: time_high (32) | time_mid (16) | version (4) | time_low (12) |

--- a/src/pytest_uuid/generators.py
+++ b/src/pytest_uuid/generators.py
@@ -421,22 +421,29 @@ def generate_uuid1_from_random(
     time_hi = rng.getrandbits(12)  # 12 bits (4 bits for version)
 
     # Generate clock_seq: 14 bits (2 bits for variant)
-    clock_seq = rng.getrandbits(14) if clock_seq is None else clock_seq & 0x3FFF
+    clock_seq_value = rng.getrandbits(14) if clock_seq is None else clock_seq & 0x3FFF
 
     # Generate node: 48 bits (MAC address)
-    node = rng.getrandbits(48) if node is None else node
+    node_value = rng.getrandbits(48) if node is None else node
 
     # Construct UUID fields with version and variant
     # time_hi_version: 4 bits version (0001 for v1) + 12 bits time_hi
     time_hi_version = (1 << 12) | time_hi
 
     # clock_seq_hi_variant: 2 bits variant (10 for RFC 4122) + 6 bits clock_seq_hi
-    clock_seq_hi = (clock_seq >> 8) & 0x3F
+    clock_seq_hi = (clock_seq_value >> 8) & 0x3F
     clock_seq_hi_variant = 0x80 | clock_seq_hi  # Set variant bits to 10
-    clock_seq_low = clock_seq & 0xFF
+    clock_seq_low = clock_seq_value & 0xFF
 
     return uuid.UUID(
-        fields=(time_low, time_mid, time_hi_version, clock_seq_hi_variant, clock_seq_low, node)
+        fields=(
+            time_low,
+            time_mid,
+            time_hi_version,
+            clock_seq_hi_variant,
+            clock_seq_low,
+            node_value,
+        )
     )
 
 
@@ -464,10 +471,10 @@ def generate_uuid6_from_random(
     time_low = rng.getrandbits(12)  # 12 bits (with 4 bits for version)
 
     # Generate clock_seq: 14 bits
-    clock_seq = rng.getrandbits(14) if clock_seq is None else clock_seq & 0x3FFF
+    clock_seq_value = rng.getrandbits(14) if clock_seq is None else clock_seq & 0x3FFF
 
     # Generate node: 48 bits
-    node = rng.getrandbits(48) if node is None else node
+    node_value = rng.getrandbits(48) if node is None else node
 
     # Construct the 128-bit UUID
     # Format: time_high (32) | time_mid (16) | version (4) | time_low (12) |
@@ -477,8 +484,8 @@ def generate_uuid6_from_random(
     int_val |= 6 << 76  # Version 6
     int_val |= time_low << 64
     int_val |= 0x2 << 62  # Variant (10 binary)
-    int_val |= clock_seq << 48
-    int_val |= node
+    int_val |= clock_seq_value << 48
+    int_val |= node_value
 
     return uuid.UUID(int=int_val)
 

--- a/src/pytest_uuid/plugin.py
+++ b/src/pytest_uuid/plugin.py
@@ -251,10 +251,14 @@ class UUID4Mocker(CallTrackingMixin):
             self._ignore_list = base_ignore + self._ignore_extra
 
     def reset(self) -> None:
-        """Reset the mocker to its initial state."""
+        """Reset the mocker to its initial state.
+
+        Clears the generator and all call tracking data. User configuration
+        (set_ignore, set_exhaustion_behavior) is preserved.
+        """
         self._generator = None
         self._reset_tracking()
-        # Reset ignore list based on ignore_defaults setting
+        # Reset ignore list based on ignore_defaults setting, preserving user config
         config = get_config()
         with self._tracking_lock:
             if self._ignore_defaults:
@@ -815,17 +819,20 @@ class _BaseUUIDMocker(CallTrackingMixin):
             self._generator._on_exhausted = self._on_exhausted
 
     def reset(self) -> None:
-        """Reset the mocker to its initial state."""
+        """Reset the mocker to its initial state.
+
+        Clears the generator and all call tracking data. User configuration
+        (set_ignore, set_exhaustion_behavior) is preserved.
+        """
         self._generator = None
         self._reset_tracking()
-        # Reset ignore list based on ignore_defaults setting
+        # Reset ignore list based on ignore_defaults setting, preserving user config
         config = get_config()
         with self._tracking_lock:
-            self._ignore_extra = ()
             if self._ignore_defaults:
-                self._ignore_list = config.get_ignore_list()
+                self._ignore_list = config.get_ignore_list() + self._ignore_extra
             else:
-                self._ignore_list = ()
+                self._ignore_list = self._ignore_extra
 
     def set_ignore(self, *module_prefixes: str) -> None:
         """Set modules to ignore when mocking (thread-safe).

--- a/src/pytest_uuid/plugin.py
+++ b/src/pytest_uuid/plugin.py
@@ -32,8 +32,15 @@ Lifecycle:
     - pytest_unconfigure: Clears config state
 
 Thread Safety:
-    The fixtures are NOT thread-safe. For multi-threaded tests, use
-    separate fixtures per thread or synchronize access.
+    UUID generation is thread-safe: multiple threads can safely call uuid.uuid4()
+    (or other UUID functions) while mockers are active. The underlying proxy system
+    uses proper locking.
+
+    Call tracking is NOT thread-safe: the call_count, generated_uuids, calls, and
+    related properties may have race conditions if multiple threads generate UUIDs
+    simultaneously. This is acceptable for most test scenarios where threads don't
+    need accurate call counts. If you need thread-safe tracking, synchronize access
+    to the mocker or use separate mockers per thread.
 """
 
 from __future__ import annotations

--- a/src/pytest_uuid/types.py
+++ b/src/pytest_uuid/types.py
@@ -29,6 +29,17 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 if TYPE_CHECKING:
     from pytest_uuid.generators import ExhaustionBehavior, UUIDGenerator
 
+__all__ = [
+    "NamespaceUUIDCall",
+    "NamespaceUUIDSpyProtocol",
+    "TimeBasedUUIDMockerProtocol",
+    "UUID4MockerProtocol",
+    "UUIDCall",
+    "UUIDMockerProtocol",
+    "UUIDSpyProtocol",
+    "UUIDVersionMockerProtocol",
+]
+
 
 @dataclass(frozen=True)
 class UUIDCall:

--- a/src/pytest_uuid/types.py
+++ b/src/pytest_uuid/types.py
@@ -55,15 +55,15 @@ class UUIDCall:
 
     Example:
         def test_inspect_calls(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
             uuid.uuid4()
 
-            call = mock_uuid.calls[0]
+            call = mock_uuid.uuid4.calls[0]
             assert call.was_mocked is True
             assert call.uuid_version == 4
             assert call.caller_module == "test_example"
-            assert call.caller_function == "test_tracking"
-            assert call.caller_qualname == "test_tracking"  # or "MyClass.method"
+            assert call.caller_function == "test_inspect_calls"
+            assert call.caller_qualname == "test_inspect_calls"
             assert call.caller_line is not None
     """
 
@@ -159,6 +159,23 @@ class UUIDVersionMockerProtocol(Protocol):
 
     def reset(self) -> None:
         """Reset the mocker to its initial state."""
+        ...
+
+    def set_ignore(self, *module_prefixes: str) -> None:
+        """Set modules to ignore when mocking.
+
+        Args:
+            *module_prefixes: Module name prefixes to exclude from patching.
+                             Calls from these modules will return real UUIDs.
+        """
+        ...
+
+    def set_seed_from_node(self) -> None:
+        """Set the seed from the current test's node ID.
+
+        Raises:
+            RuntimeError: If node ID is not available.
+        """
         ...
 
     def spy(self) -> None:
@@ -264,6 +281,7 @@ class UUID4MockerProtocol(UUIDVersionMockerProtocol, Protocol):
     """Protocol for UUID4 mocker with additional uuid4-specific methods.
 
     This extends UUIDVersionMockerProtocol with methods specific to uuid4.
+    Currently, the only uuid4-specific method is set_default().
     """
 
     def set_default(self, default_uuid: str | uuid.UUID) -> None:
@@ -271,23 +289,6 @@ class UUID4MockerProtocol(UUIDVersionMockerProtocol, Protocol):
 
         Args:
             default_uuid: The UUID to always return.
-        """
-        ...
-
-    def set_seed_from_node(self) -> None:
-        """Set the seed from the current test's node ID.
-
-        Raises:
-            RuntimeError: If node ID is not available.
-        """
-        ...
-
-    def set_ignore(self, *module_prefixes: str) -> None:
-        """Set modules to ignore when mocking uuid.uuid4().
-
-        Args:
-            *module_prefixes: Module name prefixes to exclude from patching.
-                             Calls from these modules will return real UUIDs.
         """
         ...
 

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -92,13 +92,13 @@ def test_mock_uuid_spy_method(pytester):
 
         def test_spy_method(mock_uuid):
             # Set up some mocking first
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
             mocked = uuid.uuid4()
             assert str(mocked) == "12345678-1234-4678-8234-567812345678"
-            assert mock_uuid.call_count == 1
+            assert mock_uuid.uuid4.call_count == 1
 
             # Switch to spy mode
-            mock_uuid.spy()
+            mock_uuid.uuid4.spy()
 
             # Now should return real UUIDs but still track
             # Note: call_count continues from before (accumulates)
@@ -107,7 +107,7 @@ def test_mock_uuid_spy_method(pytester):
 
             assert str(real1) != "12345678-1234-4678-8234-567812345678"
             assert real1 != real2
-            assert mock_uuid.call_count == 3  # 1 mocked + 2 spy calls
+            assert mock_uuid.uuid4.call_count == 3  # 1 mocked + 2 spy calls
         """
     )
 
@@ -159,7 +159,7 @@ def test_mock_uuid_tracks_caller_module(pytester):
         import helper_module
 
         def test_caller_module_tracked(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 
             # Call from this test module
             uuid.uuid4()
@@ -167,16 +167,16 @@ def test_mock_uuid_tracks_caller_module(pytester):
             # Call from helper module
             helper_module.generate_uuid()
 
-            assert mock_uuid.call_count == 2
-            assert len(mock_uuid.calls) == 2
+            assert mock_uuid.uuid4.call_count == 2
+            assert len(mock_uuid.uuid4.calls) == 2
 
             # Check first call came from this test
-            call1 = mock_uuid.calls[0]
+            call1 = mock_uuid.uuid4.calls[0]
             assert "test_caller_tracking" in call1.caller_module
             assert call1.was_mocked is True
 
             # Check second call came from helper
-            call2 = mock_uuid.calls[1]
+            call2 = mock_uuid.uuid4.calls[1]
             assert "helper_module" in call2.caller_module
             assert call2.was_mocked is True
         """
@@ -213,7 +213,7 @@ def test_mock_uuid_calls_from_filter(pytester):
         import myapp_utils
 
         def test_calls_from_filter(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 
             # Make calls from different modules
             uuid.uuid4()  # From test module
@@ -221,18 +221,18 @@ def test_mock_uuid_calls_from_filter(pytester):
             myapp_utils.generate_id()  # From myapp_utils
 
             # Filter by prefix
-            model_calls = mock_uuid.calls_from("myapp_models")
+            model_calls = mock_uuid.uuid4.calls_from("myapp_models")
             assert len(model_calls) == 1
 
-            util_calls = mock_uuid.calls_from("myapp_utils")
+            util_calls = mock_uuid.uuid4.calls_from("myapp_utils")
             assert len(util_calls) == 1
 
             # Filter by broader prefix
-            all_myapp = mock_uuid.calls_from("myapp")
+            all_myapp = mock_uuid.uuid4.calls_from("myapp")
             assert len(all_myapp) == 2
 
             # No matches
-            other_calls = mock_uuid.calls_from("other_package")
+            other_calls = mock_uuid.uuid4.calls_from("other_package")
             assert len(other_calls) == 0
         """
     )
@@ -248,7 +248,7 @@ def test_mock_uuid_tracks_caller_line_and_function(pytester):
 import uuid
 
 def test_line_and_function_tracked(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 
     # First call on this line
     uuid.uuid4()  # line 8
@@ -256,9 +256,9 @@ def test_line_and_function_tracked(mock_uuid):
     # Second call on different line
     uuid.uuid4()  # line 11
 
-    assert mock_uuid.call_count == 2
-    call1 = mock_uuid.calls[0]
-    call2 = mock_uuid.calls[1]
+    assert mock_uuid.uuid4.call_count == 2
+    call1 = mock_uuid.uuid4.calls[0]
+    call2 = mock_uuid.uuid4.calls[1]
 
     # Both calls should have line numbers
     assert call1.caller_line is not None
@@ -301,7 +301,7 @@ import uuid
 import helper_funcs
 
 def test_function_names_tracked(mock_uuid):
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 
     # Call from this test function
     uuid.uuid4()
@@ -314,13 +314,13 @@ def test_function_names_tracked(mock_uuid):
     obj = helper_funcs.MyClass()
     obj.method_three()
 
-    assert mock_uuid.call_count == 4
+    assert mock_uuid.uuid4.call_count == 4
 
     # Verify function names
-    assert mock_uuid.calls[0].caller_function == "test_function_names_tracked"
-    assert mock_uuid.calls[1].caller_function == "function_one"
-    assert mock_uuid.calls[2].caller_function == "function_two"
-    assert mock_uuid.calls[3].caller_function == "method_three"
+    assert mock_uuid.uuid4.calls[0].caller_function == "test_function_names_tracked"
+    assert mock_uuid.uuid4.calls[1].caller_function == "function_one"
+    assert mock_uuid.uuid4.calls[2].caller_function == "function_two"
+    assert mock_uuid.uuid4.calls[3].caller_function == "method_three"
 """
     )
 
@@ -400,29 +400,29 @@ def test_mock_uuid_mocked_vs_real_with_spy_mode(pytester):
 
         def test_mocked_vs_real(mock_uuid):
             # Start with mocked
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
             mocked1 = uuid.uuid4()
             mocked2 = uuid.uuid4()
 
             # Switch to spy mode (real UUIDs)
-            mock_uuid.spy()
+            mock_uuid.uuid4.spy()
             real1 = uuid.uuid4()
             real2 = uuid.uuid4()
 
             # Verify call tracking
-            assert mock_uuid.call_count == 4
-            assert mock_uuid.mocked_count == 2
-            assert mock_uuid.real_count == 2
+            assert mock_uuid.uuid4.call_count == 4
+            assert mock_uuid.uuid4.mocked_count == 2
+            assert mock_uuid.uuid4.real_count == 2
 
             # Verify mocked_calls
-            mocked_calls = mock_uuid.mocked_calls
+            mocked_calls = mock_uuid.uuid4.mocked_calls
             assert len(mocked_calls) == 2
             assert all(c.was_mocked for c in mocked_calls)
             assert mocked_calls[0].uuid == mocked1
             assert mocked_calls[1].uuid == mocked2
 
             # Verify real_calls
-            real_calls = mock_uuid.real_calls
+            real_calls = mock_uuid.uuid4.real_calls
             assert len(real_calls) == 2
             assert all(not c.was_mocked for c in real_calls)
             assert real_calls[0].uuid == real1
@@ -519,7 +519,7 @@ def test_xdist_worker_isolation(pytester):
         import uuid
 
         def test_worker_a_uuid(mock_uuid):
-            mock_uuid.set("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
+            mock_uuid.uuid4.set("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
             result = uuid.uuid4()
             assert str(result) == "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
         """
@@ -530,7 +530,7 @@ def test_xdist_worker_isolation(pytester):
         import uuid
 
         def test_worker_b_uuid(mock_uuid):
-            mock_uuid.set("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb")
+            mock_uuid.uuid4.set("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb")
             result = uuid.uuid4()
             assert str(result) == "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
         """
@@ -541,7 +541,7 @@ def test_xdist_worker_isolation(pytester):
         import uuid
 
         def test_worker_c_uuid(mock_uuid):
-            mock_uuid.set("cccccccc-cccc-4ccc-accc-cccccccccccc")
+            mock_uuid.uuid4.set("cccccccc-cccc-4ccc-accc-cccccccccccc")
             result = uuid.uuid4()
             assert str(result) == "cccccccc-cccc-4ccc-accc-cccccccccccc"
         """
@@ -561,7 +561,7 @@ def test_xdist_no_cross_contamination(pytester):
         import time
 
         def test_slow_with_uuid_a(mock_uuid):
-            mock_uuid.set("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
+            mock_uuid.uuid4.set("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
             # Simulate slow test to increase chance of parallel execution
             time.sleep(0.1)
             # Verify our UUID wasn't changed by another worker
@@ -570,13 +570,13 @@ def test_xdist_no_cross_contamination(pytester):
             assert str(uuid.uuid4()) == "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
 
         def test_fast_with_uuid_b(mock_uuid):
-            mock_uuid.set("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb")
+            mock_uuid.uuid4.set("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb")
             # These should execute while test_slow is sleeping
             assert str(uuid.uuid4()) == "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
             assert str(uuid.uuid4()) == "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
 
         def test_fast_with_uuid_c(mock_uuid):
-            mock_uuid.set("cccccccc-cccc-4ccc-accc-cccccccccccc")
+            mock_uuid.uuid4.set("cccccccc-cccc-4ccc-accc-cccccccccccc")
             assert str(uuid.uuid4()) == "cccccccc-cccc-4ccc-accc-cccccccccccc"
             assert str(uuid.uuid4()) == "cccccccc-cccc-4ccc-accc-cccccccccccc"
         """
@@ -698,7 +698,7 @@ def test_parametrize_with_fixture(pytester):
             "33333333-3333-4333-8333-333333333333",
         ])
         def test_parametrized_fixture(mock_uuid, expected_uuid):
-            mock_uuid.set(expected_uuid)
+            mock_uuid.uuid4.set(expected_uuid)
             result = uuid.uuid4()
             assert str(result) == expected_uuid
         """

--- a/tests/integration/test_ignore.py
+++ b/tests/integration/test_ignore.py
@@ -1,4 +1,4 @@
-"""Integration tests for mock_uuid.set_ignore() functionality.
+"""Integration tests for mock_uuid.uuid4.set_ignore() functionality.
 
 These tests verify that the ignore list feature allows certain modules
 to receive real UUIDs while others receive mocked UUIDs.
@@ -28,8 +28,8 @@ def test_ignore_single_module(pytester):
         import helper
 
         def test_ignore_module(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
-            mock_uuid.set_ignore("helper")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set_ignore("helper")
 
             # Direct call should be mocked
             mocked = uuid.uuid4()
@@ -40,8 +40,8 @@ def test_ignore_single_module(pytester):
             assert str(real) != "12345678-1234-4678-8234-567812345678"
 
             # Verify tracking
-            assert mock_uuid.mocked_count == 1
-            assert mock_uuid.real_count == 1
+            assert mock_uuid.uuid4.mocked_count == 1
+            assert mock_uuid.uuid4.real_count == 1
         """
     )
 
@@ -78,8 +78,8 @@ def test_ignore_multiple_modules(pytester):
         import pkg_b
 
         def test_ignore_multiple(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
-            mock_uuid.set_ignore("pkg_a", "pkg_b")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set_ignore("pkg_a", "pkg_b")
 
             # Direct call should be mocked
             mocked = uuid.uuid4()
@@ -94,8 +94,8 @@ def test_ignore_multiple_modules(pytester):
             assert real_a != real_b  # They should be different random UUIDs
 
             # Verify tracking
-            assert mock_uuid.mocked_count == 1
-            assert mock_uuid.real_count == 2
+            assert mock_uuid.uuid4.mocked_count == 1
+            assert mock_uuid.uuid4.real_count == 2
         """
     )
 
@@ -122,14 +122,14 @@ def test_ignore_updates_dynamically(pytester):
         import helper
 
         def test_dynamic_ignore(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
 
             # Initially, helper is not ignored
             uuid1 = helper.get_uuid()
             assert str(uuid1) == "12345678-1234-4678-8234-567812345678"
 
             # Add helper to ignore list
-            mock_uuid.set_ignore("helper")
+            mock_uuid.uuid4.set_ignore("helper")
 
             # Now helper calls should be real
             uuid2 = helper.get_uuid()
@@ -164,16 +164,16 @@ def test_ignore_with_reset(pytester):
         import helper
 
         def test_reset_preserves_ignore(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
-            mock_uuid.set_ignore("helper")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set_ignore("helper")
 
             # Helper calls should be real
             uuid1 = helper.get_uuid()
             assert str(uuid1) != "12345678-1234-4678-8234-567812345678"
 
             # Reset the mocker
-            mock_uuid.reset()
-            mock_uuid.set("87654321-8765-4321-8765-876543218765")
+            mock_uuid.uuid4.reset()
+            mock_uuid.uuid4.set("87654321-8765-4321-8765-876543218765")
 
             # Helper calls should still be real after reset
             uuid2 = helper.get_uuid()
@@ -217,8 +217,8 @@ def test_ignore_with_nested_calls(pytester):
         import base_module
 
         def test_nested_ignore(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
-            mock_uuid.set_ignore("base_module")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set_ignore("base_module")
 
             # Direct call should be mocked
             uuid1 = uuid.uuid4()
@@ -257,8 +257,8 @@ def test_calls_tracking_with_ignore(pytester):
         import ignored_module
 
         def test_call_tracking(mock_uuid):
-            mock_uuid.set("12345678-1234-4678-8234-567812345678")
-            mock_uuid.set_ignore("ignored_module")
+            mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+            mock_uuid.uuid4.set_ignore("ignored_module")
 
             # Make some calls
             uuid1 = uuid.uuid4()  # mocked
@@ -266,22 +266,22 @@ def test_calls_tracking_with_ignore(pytester):
             uuid3 = uuid.uuid4()  # mocked
 
             # Check overall tracking
-            assert mock_uuid.call_count == 3
-            assert len(mock_uuid.generated_uuids) == 3
+            assert mock_uuid.uuid4.call_count == 3
+            assert len(mock_uuid.uuid4.generated_uuids) == 3
 
             # Check mocked vs real
-            assert mock_uuid.mocked_count == 2
-            assert mock_uuid.real_count == 1
+            assert mock_uuid.uuid4.mocked_count == 2
+            assert mock_uuid.uuid4.real_count == 1
 
             # Check mocked_calls
-            mocked_calls = mock_uuid.mocked_calls
+            mocked_calls = mock_uuid.uuid4.mocked_calls
             assert len(mocked_calls) == 2
             for call in mocked_calls:
                 assert call.was_mocked is True
                 assert str(call.uuid) == "12345678-1234-4678-8234-567812345678"
 
             # Check real_calls
-            real_calls = mock_uuid.real_calls
+            real_calls = mock_uuid.uuid4.real_calls
             assert len(real_calls) == 1
             assert real_calls[0].was_mocked is False
             assert str(real_calls[0].uuid) != "12345678-1234-4678-8234-567812345678"

--- a/tests/integration/test_isolation.py
+++ b/tests/integration/test_isolation.py
@@ -16,7 +16,7 @@ def test_fixture_isolation_between_tests(pytester):
         import uuid
 
         def test_first(mock_uuid):
-            mock_uuid.set("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
+            mock_uuid.uuid4.set("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
             assert str(uuid.uuid4()) == "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
 
         def test_second(mock_uuid):

--- a/tests/integration/test_markers.py
+++ b/tests/integration/test_markers.py
@@ -611,3 +611,105 @@ def test_marker_freeze_uuid_backward_compat(pytester):
 
     result = pytester.runpytest("-v")
     result.assert_outcomes(passed=1)
+
+
+def test_marker_freeze_uuid1_with_node(pytester):
+    """Test that @pytest.mark.freeze_uuid1 with node parameter works."""
+    pytester.makepyfile(
+        test_marker_uuid1_node="""
+        import uuid
+        import pytest
+
+        @pytest.mark.freeze_uuid1(seed=42, node=0x123456789ABC)
+        def test_marker_uuid1_with_node():
+            result = uuid.uuid1()
+            assert isinstance(result, uuid.UUID)
+            assert result.version == 1
+            assert result.node == 0x123456789ABC
+        """
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_freeze_uuid6_applies_freezer(pytester):
+    """Test that @pytest.mark.freeze_uuid6 applies the freezer."""
+    pytester.makepyfile(
+        test_marker_uuid6="""
+        import uuid
+        import pytest
+
+        uuid6_mod = pytest.importorskip("uuid6")
+
+        @pytest.mark.freeze_uuid6("12345678-1234-6678-8234-567812345678")
+        def test_marker_uuid6_works():
+            result = uuid6_mod.uuid6()
+            assert str(result) == "12345678-1234-6678-8234-567812345678"
+        """
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_freeze_uuid6_with_seed(pytester):
+    """Test that @pytest.mark.freeze_uuid6 with seed works."""
+    pytester.makepyfile(
+        test_marker_uuid6_seed="""
+        import uuid
+        import pytest
+
+        uuid6_mod = pytest.importorskip("uuid6")
+
+        @pytest.mark.freeze_uuid6(seed=42)
+        def test_marker_uuid6_seeded():
+            result = uuid6_mod.uuid6()
+            assert isinstance(result, uuid.UUID)
+            assert result.version == 6
+        """
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_freeze_uuid8_applies_freezer(pytester):
+    """Test that @pytest.mark.freeze_uuid8 applies the freezer."""
+    pytester.makepyfile(
+        test_marker_uuid8="""
+        import uuid
+        import pytest
+
+        uuid6_mod = pytest.importorskip("uuid6")
+
+        @pytest.mark.freeze_uuid8("12345678-1234-8678-8234-567812345678")
+        def test_marker_uuid8_works():
+            result = uuid6_mod.uuid8()
+            assert str(result) == "12345678-1234-8678-8234-567812345678"
+        """
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_freeze_uuid8_with_seed(pytester):
+    """Test that @pytest.mark.freeze_uuid8 with seed works."""
+    pytester.makepyfile(
+        test_marker_uuid8_seed="""
+        import uuid
+        import pytest
+
+        uuid6_mod = pytest.importorskip("uuid6")
+
+        @pytest.mark.freeze_uuid8(seed=42)
+        def test_marker_uuid8_seeded():
+            result = uuid6_mod.uuid8()
+            assert isinstance(result, uuid.UUID)
+            assert result.version == 8
+        """
+    )
+
+    result = pytester.runpytest("-v")
+    result.assert_outcomes(passed=1)

--- a/tests/integration/test_markers.py
+++ b/tests/integration/test_markers.py
@@ -374,7 +374,7 @@ def test_marker_with_mock_uuid_fixture_override(pytester):
             assert first == "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
 
             # Fixture can override to a different UUID
-            mock_uuid.set("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb")
+            mock_uuid.uuid4.set("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb")
             second = str(uuid.uuid4())
             assert second == "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
         """
@@ -406,7 +406,7 @@ def test_marker_with_sequence_exhaustion_and_fixture(pytester):
             assert str(uuid.uuid4()) == "11111111-1111-4111-8111-111111111111"
 
             # But fixture can still override
-            mock_uuid.set("33333333-3333-4333-8333-333333333333")
+            mock_uuid.uuid4.set("33333333-3333-4333-8333-333333333333")
             assert str(uuid.uuid4()) == "33333333-3333-4333-8333-333333333333"
         """
     )

--- a/tests/integration/test_markers.py
+++ b/tests/integration/test_markers.py
@@ -637,14 +637,20 @@ def test_marker_freeze_uuid6_applies_freezer(pytester):
     """Test that @pytest.mark.freeze_uuid6 applies the freezer."""
     pytester.makepyfile(
         test_marker_uuid6="""
+        import sys
         import uuid
         import pytest
 
-        uuid6_mod = pytest.importorskip("uuid6")
+        # Python 3.14+ has uuid6 in stdlib, older versions need uuid6 package
+        if sys.version_info >= (3, 14):
+            uuid6_func = uuid.uuid6
+        else:
+            uuid6_mod = pytest.importorskip("uuid6")
+            uuid6_func = uuid6_mod.uuid6
 
         @pytest.mark.freeze_uuid6("12345678-1234-6678-8234-567812345678")
         def test_marker_uuid6_works():
-            result = uuid6_mod.uuid6()
+            result = uuid6_func()
             assert str(result) == "12345678-1234-6678-8234-567812345678"
         """
     )
@@ -657,14 +663,19 @@ def test_marker_freeze_uuid6_with_seed(pytester):
     """Test that @pytest.mark.freeze_uuid6 with seed works."""
     pytester.makepyfile(
         test_marker_uuid6_seed="""
+        import sys
         import uuid
         import pytest
 
-        uuid6_mod = pytest.importorskip("uuid6")
+        if sys.version_info >= (3, 14):
+            uuid6_func = uuid.uuid6
+        else:
+            uuid6_mod = pytest.importorskip("uuid6")
+            uuid6_func = uuid6_mod.uuid6
 
         @pytest.mark.freeze_uuid6(seed=42)
         def test_marker_uuid6_seeded():
-            result = uuid6_mod.uuid6()
+            result = uuid6_func()
             assert isinstance(result, uuid.UUID)
             assert result.version == 6
         """
@@ -678,14 +689,19 @@ def test_marker_freeze_uuid8_applies_freezer(pytester):
     """Test that @pytest.mark.freeze_uuid8 applies the freezer."""
     pytester.makepyfile(
         test_marker_uuid8="""
+        import sys
         import uuid
         import pytest
 
-        uuid6_mod = pytest.importorskip("uuid6")
+        if sys.version_info >= (3, 14):
+            uuid8_func = uuid.uuid8
+        else:
+            uuid6_mod = pytest.importorskip("uuid6")
+            uuid8_func = uuid6_mod.uuid8
 
         @pytest.mark.freeze_uuid8("12345678-1234-8678-8234-567812345678")
         def test_marker_uuid8_works():
-            result = uuid6_mod.uuid8()
+            result = uuid8_func()
             assert str(result) == "12345678-1234-8678-8234-567812345678"
         """
     )
@@ -698,14 +714,19 @@ def test_marker_freeze_uuid8_with_seed(pytester):
     """Test that @pytest.mark.freeze_uuid8 with seed works."""
     pytester.makepyfile(
         test_marker_uuid8_seed="""
+        import sys
         import uuid
         import pytest
 
-        uuid6_mod = pytest.importorskip("uuid6")
+        if sys.version_info >= (3, 14):
+            uuid8_func = uuid.uuid8
+        else:
+            uuid6_mod = pytest.importorskip("uuid6")
+            uuid8_func = uuid6_mod.uuid8
 
         @pytest.mark.freeze_uuid8(seed=42)
         def test_marker_uuid8_seeded():
-            result = uuid6_mod.uuid8()
+            result = uuid8_func()
             assert isinstance(result, uuid.UUID)
             assert result.version == 8
         """

--- a/tests/integration/test_stress_parallel.py
+++ b/tests/integration/test_stress_parallel.py
@@ -139,7 +139,7 @@ def test_service_class_unmocked(_iteration):
 @pytest.mark.parametrize("expected_uuid", MOCK_UUIDS[:15])
 def test_fixture_with_external_module(mock_uuid, expected_uuid):
     """Test mock_uuid fixture works with external module."""
-    mock_uuid.set(expected_uuid)
+    mock_uuid.uuid4.set(expected_uuid)
     result = generate_id()
     assert str(result) == expected_uuid
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -13,6 +13,7 @@ from pytest_uuid.api import (
     freeze_uuid,
     freeze_uuid1,
     freeze_uuid4,
+    freeze_uuid6,
     freeze_uuid7,
     freeze_uuid8,
 )
@@ -660,6 +661,37 @@ class TestFreezeUUID1:
         """Test that uuid_version property returns correct version."""
         with freeze_uuid1(seed=42) as freezer:
             assert freezer.uuid_version == "uuid1"
+
+
+class TestFreezeUUID6:
+    """Tests for freeze_uuid6 function."""
+
+    def test_static_uuid(self):
+        """Test freeze_uuid6 with a static UUID."""
+        uuid6_mod = pytest.importorskip("uuid6")
+
+        with freeze_uuid6("12345678-1234-6678-8234-567812345678"):
+            result = uuid6_mod.uuid6()
+            assert str(result) == "12345678-1234-6678-8234-567812345678"
+
+    def test_seeded_generation(self):
+        """Test freeze_uuid6 with seeded generation."""
+        uuid6_mod = pytest.importorskip("uuid6")
+
+        with freeze_uuid6(seed=42):
+            uuid1 = uuid6_mod.uuid6()
+
+        with freeze_uuid6(seed=42):
+            uuid2 = uuid6_mod.uuid6()
+
+        assert uuid1 == uuid2
+        assert uuid1.version == 6
+
+    def test_uuid_version_property(self):
+        """Test that uuid_version property returns correct version."""
+        pytest.importorskip("uuid6")
+        with freeze_uuid6(seed=42) as freezer:
+            assert freezer.uuid_version == "uuid6"
 
 
 class TestFreezeUUID7:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -792,6 +792,12 @@ class TestFreezeUUID7:
             assert str(uuid6_mod.uuid7()) == uuids[0]
             assert str(uuid6_mod.uuid7()) == uuids[1]
 
+    def test_uuid_version_property(self):
+        """Test that uuid_version property returns correct version."""
+        pytest.importorskip("uuid6")
+        with freeze_uuid7(seed=42) as freezer:
+            assert freezer.uuid_version == "uuid7"
+
 
 class TestFreezeUUID8:
     """Tests for freeze_uuid8 function."""
@@ -827,6 +833,12 @@ class TestFreezeUUID8:
         with freeze_uuid8(uuids):
             assert str(uuid6_mod.uuid8()) == uuids[0]
             assert str(uuid6_mod.uuid8()) == uuids[1]
+
+    def test_uuid_version_property(self):
+        """Test that uuid_version property returns correct version."""
+        pytest.importorskip("uuid6")
+        with freeze_uuid8(seed=42) as freezer:
+            assert freezer.uuid_version == "uuid8"
 
 
 class TestStackingMultipleVersionFreezers:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+import sys
 import threading
 import uuid
 
@@ -696,61 +697,69 @@ class TestFreezeUUID1:
 class TestFreezeUUID6:
     """Tests for freeze_uuid6 function."""
 
+    @staticmethod
+    def _get_uuid6_func():
+        """Get uuid6 function from stdlib (3.14+) or uuid6 package."""
+        if sys.version_info >= (3, 14):
+            return uuid.uuid6
+        uuid6_mod = pytest.importorskip("uuid6")
+        return uuid6_mod.uuid6
+
     def test_static_uuid(self):
         """Test freeze_uuid6 with a static UUID."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid6_func = self._get_uuid6_func()
 
         with freeze_uuid6("12345678-1234-6678-8234-567812345678"):
-            result = uuid6_mod.uuid6()
+            result = uuid6_func()
             assert str(result) == "12345678-1234-6678-8234-567812345678"
 
     def test_seeded_generation(self):
         """Test freeze_uuid6 with seeded generation."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid6_func = self._get_uuid6_func()
 
         with freeze_uuid6(seed=42):
-            uuid1 = uuid6_mod.uuid6()
+            uuid1 = uuid6_func()
 
         with freeze_uuid6(seed=42):
-            uuid2 = uuid6_mod.uuid6()
+            uuid2 = uuid6_func()
 
         assert uuid1 == uuid2
         assert uuid1.version == 6
 
     def test_seeded_with_fixed_node(self):
         """Test freeze_uuid6 with seeded generation and fixed node."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid6_func = self._get_uuid6_func()
         fixed_node = 0x123456789ABC
 
         with freeze_uuid6(seed=42, node=fixed_node):
-            result = uuid6_mod.uuid6()
+            result = uuid6_func()
             assert result.node == fixed_node
             assert result.version == 6
 
     def test_seeded_with_fixed_clock_seq(self):
         """Test freeze_uuid6 with seeded generation and fixed clock_seq."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid6_func = self._get_uuid6_func()
         fixed_clock_seq = 0x1234
 
         with freeze_uuid6(seed=42, clock_seq=fixed_clock_seq):
-            result = uuid6_mod.uuid6()
+            result = uuid6_func()
             assert result.clock_seq == fixed_clock_seq
             assert result.version == 6
 
     def test_sequence(self):
         """Test freeze_uuid6 with multiple UUIDs."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid6_func = self._get_uuid6_func()
         uuids = [
             "12345678-1234-6678-8234-567812345678",
             "87654321-4321-6876-8432-876543218765",
         ]
         with freeze_uuid6(uuids):
-            assert str(uuid6_mod.uuid6()) == uuids[0]
-            assert str(uuid6_mod.uuid6()) == uuids[1]
+            assert str(uuid6_func()) == uuids[0]
+            assert str(uuid6_func()) == uuids[1]
 
     def test_uuid_version_property(self):
         """Test that uuid_version property returns correct version."""
-        pytest.importorskip("uuid6")
+        self._get_uuid6_func()  # Ensure uuid6 is available
         with freeze_uuid6(seed=42) as freezer:
             assert freezer.uuid_version == "uuid6"
 
@@ -758,43 +767,49 @@ class TestFreezeUUID6:
 class TestFreezeUUID7:
     """Tests for freeze_uuid7 function."""
 
+    @staticmethod
+    def _get_uuid7_func():
+        """Get uuid7 function from stdlib (3.14+) or uuid6 package."""
+        if sys.version_info >= (3, 14):
+            return uuid.uuid7
+        uuid6_mod = pytest.importorskip("uuid6")
+        return uuid6_mod.uuid7
+
     def test_static_uuid(self):
         """Test freeze_uuid7 with a static UUID."""
-        # Use uuid7 (requires uuid6 package or Python 3.14+)
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid7_func = self._get_uuid7_func()
 
-        # Import uuid7 from the patched uuid6 module (NOT from _compat)
         with freeze_uuid7("01234567-89ab-7def-8123-456789abcdef"):
-            result = uuid6_mod.uuid7()
+            result = uuid7_func()
             assert str(result) == "01234567-89ab-7def-8123-456789abcdef"
 
     def test_seeded_generation(self):
         """Test freeze_uuid7 with seeded generation."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid7_func = self._get_uuid7_func()
 
         with freeze_uuid7(seed=42):
-            uuid1 = uuid6_mod.uuid7()
+            uuid1 = uuid7_func()
 
         with freeze_uuid7(seed=42):
-            uuid2 = uuid6_mod.uuid7()
+            uuid2 = uuid7_func()
 
         assert uuid1 == uuid2
         assert uuid1.version == 7
 
     def test_sequence(self):
         """Test freeze_uuid7 with multiple UUIDs."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid7_func = self._get_uuid7_func()
         uuids = [
             "01234567-89ab-7def-8123-456789abcdef",
             "fedcba98-7654-7321-8fed-cba987654321",
         ]
         with freeze_uuid7(uuids):
-            assert str(uuid6_mod.uuid7()) == uuids[0]
-            assert str(uuid6_mod.uuid7()) == uuids[1]
+            assert str(uuid7_func()) == uuids[0]
+            assert str(uuid7_func()) == uuids[1]
 
     def test_uuid_version_property(self):
         """Test that uuid_version property returns correct version."""
-        pytest.importorskip("uuid6")
+        self._get_uuid7_func()  # Ensure uuid7 is available
         with freeze_uuid7(seed=42) as freezer:
             assert freezer.uuid_version == "uuid7"
 
@@ -802,41 +817,49 @@ class TestFreezeUUID7:
 class TestFreezeUUID8:
     """Tests for freeze_uuid8 function."""
 
+    @staticmethod
+    def _get_uuid8_func():
+        """Get uuid8 function from stdlib (3.14+) or uuid6 package."""
+        if sys.version_info >= (3, 14):
+            return uuid.uuid8
+        uuid6_mod = pytest.importorskip("uuid6")
+        return uuid6_mod.uuid8
+
     def test_static_uuid(self):
         """Test freeze_uuid8 with a static UUID."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid8_func = self._get_uuid8_func()
 
         with freeze_uuid8("12345678-1234-8678-8234-567812345678"):
-            result = uuid6_mod.uuid8()
+            result = uuid8_func()
             assert str(result) == "12345678-1234-8678-8234-567812345678"
 
     def test_seeded_generation(self):
         """Test freeze_uuid8 with seeded generation."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid8_func = self._get_uuid8_func()
 
         with freeze_uuid8(seed=42):
-            uuid1 = uuid6_mod.uuid8()
+            uuid1 = uuid8_func()
 
         with freeze_uuid8(seed=42):
-            uuid2 = uuid6_mod.uuid8()
+            uuid2 = uuid8_func()
 
         assert uuid1 == uuid2
         assert uuid1.version == 8
 
     def test_sequence(self):
         """Test freeze_uuid8 with multiple UUIDs."""
-        uuid6_mod = pytest.importorskip("uuid6")
+        uuid8_func = self._get_uuid8_func()
         uuids = [
             "12345678-1234-8678-8234-567812345678",
             "87654321-4321-8876-8432-876543218765",
         ]
         with freeze_uuid8(uuids):
-            assert str(uuid6_mod.uuid8()) == uuids[0]
-            assert str(uuid6_mod.uuid8()) == uuids[1]
+            assert str(uuid8_func()) == uuids[0]
+            assert str(uuid8_func()) == uuids[1]
 
     def test_uuid_version_property(self):
         """Test that uuid_version property returns correct version."""
-        pytest.importorskip("uuid6")
+        self._get_uuid8_func()  # Ensure uuid8 is available
         with freeze_uuid8(seed=42) as freezer:
             assert freezer.uuid_version == "uuid8"
 

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -508,9 +508,7 @@ def test_spy_uuid_then_mock_uuid_uuid4_conflict_raises_error(pytester):
 
     result = pytester.runpytest("-v")
     result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines(
-        ["*UsageError*Cannot use both*mock_uuid*spy_uuid*"]
-    )
+    result.stdout.fnmatch_lines(["*UsageError*Cannot use both*mock_uuid*spy_uuid*"])
 
 
 def test_mock_uuid_uuid4_then_spy_uuid_conflict_raises_error(pytester):
@@ -532,6 +530,4 @@ def test_mock_uuid_uuid4_then_spy_uuid_conflict_raises_error(pytester):
 
     result = pytester.runpytest("-v")
     result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines(
-        ["*UsageError*Cannot use both*mock_uuid*spy_uuid*"]
-    )
+    result.stdout.fnmatch_lines(["*UsageError*Cannot use both*mock_uuid*spy_uuid*"])

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -25,7 +25,7 @@ from pytest_uuid.types import UUIDCall
 def test_mock_uuid_set_single_uuid(mock_uuid):
     """Test setting a single UUID."""
     expected = "12345678-1234-4678-8234-567812345678"
-    mock_uuid.set(expected)
+    mock_uuid.uuid4.set(expected)
 
     result = uuid.uuid4()
 
@@ -35,7 +35,7 @@ def test_mock_uuid_set_single_uuid(mock_uuid):
 def test_mock_uuid_works_with_direct_import(mock_uuid):
     """Test that mock works with 'from uuid import uuid4' pattern."""
     expected = "12345678-1234-4678-8234-567812345678"
-    mock_uuid.set(expected)
+    mock_uuid.uuid4.set(expected)
 
     # Use the directly imported uuid4 function
     result = uuid4()
@@ -46,7 +46,7 @@ def test_mock_uuid_works_with_direct_import(mock_uuid):
 def test_mock_uuid_set_single_uuid_as_object(mock_uuid):
     """Test setting a UUID using a UUID object."""
     expected = uuid.UUID("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set(expected)
+    mock_uuid.uuid4.set(expected)
 
     result = uuid.uuid4()
 
@@ -56,7 +56,7 @@ def test_mock_uuid_set_single_uuid_as_object(mock_uuid):
 def test_mock_uuid_set_default(mock_uuid):
     """Test setting a default UUID."""
     default = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
-    mock_uuid.set_default(default)
+    mock_uuid.uuid4.set_default(default)
 
     # All calls return the default
     assert str(uuid.uuid4()) == default
@@ -69,18 +69,18 @@ def test_mock_uuid_set_overrides_default(mock_uuid):
     default = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
     specific = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
 
-    mock_uuid.set_default(default)
-    mock_uuid.set(specific)
+    mock_uuid.uuid4.set_default(default)
+    mock_uuid.uuid4.set(specific)
 
     assert str(uuid.uuid4()) == specific
 
 
 def test_mock_uuid_reset_clears_everything(mock_uuid):
     """Test that reset() clears all configuration."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    mock_uuid.set_default("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set_default("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
 
-    mock_uuid.reset()
+    mock_uuid.uuid4.reset()
 
     # Should return a real random UUID now
     result = uuid.uuid4()
@@ -104,10 +104,10 @@ def test_mock_uuid_no_mock_returns_random(mock_uuid):  # noqa: ARG001
 
 def test_mock_uuid_set_seed_integer(mock_uuid):
     """Test set_seed with integer seed."""
-    mock_uuid.set_seed(42)
+    mock_uuid.uuid4.set_seed(42)
     first = uuid.uuid4()
 
-    mock_uuid.set_seed(42)
+    mock_uuid.uuid4.set_seed(42)
     second = uuid.uuid4()
 
     assert first == second
@@ -116,7 +116,7 @@ def test_mock_uuid_set_seed_integer(mock_uuid):
 def test_mock_uuid_set_seed_random_instance(mock_uuid):
     """Test set_seed with Random instance."""
     rng = random.Random(42)
-    mock_uuid.set_seed(rng)
+    mock_uuid.uuid4.set_seed(rng)
 
     result = uuid.uuid4()
     assert isinstance(result, uuid.UUID)
@@ -125,10 +125,10 @@ def test_mock_uuid_set_seed_random_instance(mock_uuid):
 
 def test_mock_uuid_set_seed_from_node(mock_uuid):
     """Test set_seed_from_node uses test node ID."""
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     first = uuid.uuid4()
 
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     second = uuid.uuid4()
 
     # Same test, same node ID, same seed
@@ -137,34 +137,34 @@ def test_mock_uuid_set_seed_from_node(mock_uuid):
 
 def test_mock_uuid_seed_property_with_integer(mock_uuid):
     """Test that seed property returns the integer seed."""
-    mock_uuid.set_seed(42)
-    assert mock_uuid.seed == 42
+    mock_uuid.uuid4.set_seed(42)
+    assert mock_uuid.uuid4.seed == 42
 
 
 def test_mock_uuid_seed_property_with_random_instance(mock_uuid):
     """Test that seed property returns None when using Random instance."""
     rng = random.Random(42)
-    mock_uuid.set_seed(rng)
-    assert mock_uuid.seed is None
+    mock_uuid.uuid4.set_seed(rng)
+    assert mock_uuid.uuid4.seed is None
 
 
 def test_mock_uuid_seed_property_from_node(mock_uuid):
     """Test that seed property returns computed seed from node ID."""
-    mock_uuid.set_seed_from_node()
+    mock_uuid.uuid4.set_seed_from_node()
     # Should return an integer derived from the node ID
-    assert mock_uuid.seed is not None
-    assert isinstance(mock_uuid.seed, int)
+    assert mock_uuid.uuid4.seed is not None
+    assert isinstance(mock_uuid.uuid4.seed, int)
 
 
 def test_mock_uuid_seed_property_with_static_uuid(mock_uuid):
     """Test that seed property returns None when using static UUIDs."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
-    assert mock_uuid.seed is None
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
+    assert mock_uuid.uuid4.seed is None
 
 
 def test_mock_uuid_seed_property_no_generator(mock_uuid):
     """Test that seed property returns None when no generator is set."""
-    assert mock_uuid.seed is None
+    assert mock_uuid.uuid4.seed is None
 
 
 @pytest.mark.parametrize(
@@ -176,8 +176,8 @@ def test_mock_uuid_seed_property_no_generator(mock_uuid):
 )
 def test_mock_uuid_set_exhaustion_behavior(mock_uuid, behavior_input):
     """Test setting exhaustion behavior with string or enum."""
-    mock_uuid.set_exhaustion_behavior(behavior_input)
-    mock_uuid.set("11111111-1111-4111-8111-111111111111")
+    mock_uuid.uuid4.set_exhaustion_behavior(behavior_input)
+    mock_uuid.uuid4.set("11111111-1111-4111-8111-111111111111")
 
     uuid.uuid4()
 
@@ -187,13 +187,13 @@ def test_mock_uuid_set_exhaustion_behavior(mock_uuid, behavior_input):
 
 def test_mock_uuid_generator_property(mock_uuid):
     """Test the generator property."""
-    assert mock_uuid.generator is None
+    assert mock_uuid.uuid4.generator is None
 
-    mock_uuid.set_seed(42)
-    assert mock_uuid.generator is not None
+    mock_uuid.uuid4.set_seed(42)
+    assert mock_uuid.uuid4.generator is not None
 
-    mock_uuid.reset()
-    assert mock_uuid.generator is None
+    mock_uuid.uuid4.reset()
+    assert mock_uuid.uuid4.generator is None
 
 
 # --- mock_uuid_factory ---
@@ -205,7 +205,7 @@ def test_mock_uuid_factory_creates_scoped_mocker(mock_uuid_factory):
 
     # With proxy approach, module_path is optional (for backward compat)
     with mock_uuid_factory() as mocker:
-        mocker.set(expected)
+        mocker.uuid4.set(expected)
         result = uuid.uuid4()
 
     assert str(result) == expected
@@ -215,14 +215,14 @@ def test_mock_uuid_factory_returns_mocker_with_all_methods(mock_uuid_factory):
     """Test that the factory returns a fully functional mocker."""
     with mock_uuid_factory() as mocker:
         # Test set
-        mocker.set("11111111-1111-4111-8111-111111111111")
+        mocker.uuid4.set("11111111-1111-4111-8111-111111111111")
         assert str(uuid.uuid4()) == "11111111-1111-4111-8111-111111111111"
 
         # Test reset
         mocker.reset()
 
         # Test set_default
-        mocker.set_default("22222222-2222-4222-8222-222222222222")
+        mocker.uuid4.set_default("22222222-2222-4222-8222-222222222222")
         assert str(uuid.uuid4()) == "22222222-2222-4222-8222-222222222222"
 
 
@@ -232,7 +232,7 @@ def test_mock_uuid_factory_accepts_module_path_for_backward_compat(mock_uuid_fac
 
     # module_path is accepted but no longer used for validation
     with mock_uuid_factory("uuid") as mocker:
-        mocker.set(expected)
+        mocker.uuid4.set(expected)
         result = uuid.uuid4()
 
     assert str(result) == expected
@@ -255,15 +255,17 @@ def test_mock_uuid_factory_fixture_is_available(mock_uuid_factory):
 def test_mock_uuid_factory_ignore_defaults_true_by_default(mock_uuid_factory):
     """Test that ignore_defaults=True is the default behavior."""
     with mock_uuid_factory() as mocker:
+        # Access uuid4 to initialize the sub-mocker
         # Default behavior: botocore should be in the ignore list
-        assert "botocore" in mocker._ignore_list
+        assert "botocore" in mocker.uuid4._ignore_list
 
 
 def test_mock_uuid_factory_ignore_defaults_false(mock_uuid_factory):
     """Test that ignore_defaults=False excludes default packages from ignore list."""
     with mock_uuid_factory(ignore_defaults=False) as mocker:
+        # Access uuid4 to initialize the sub-mocker
         # With ignore_defaults=False, botocore should NOT be in the ignore list
-        assert "botocore" not in mocker._ignore_list
+        assert "botocore" not in mocker.uuid4._ignore_list
 
 
 # --- Edge cases ---
@@ -271,7 +273,7 @@ def test_mock_uuid_factory_ignore_defaults_false(mock_uuid_factory):
 
 def test_mock_uuid_empty_set_call(mock_uuid):
     """Test calling set() with no arguments."""
-    mock_uuid.set()  # Should not raise
+    mock_uuid.uuid4.set()  # Should not raise
     # Should return random UUIDs since no UUIDs were set
     result = uuid.uuid4()
     assert isinstance(result, uuid.UUID)
@@ -280,15 +282,15 @@ def test_mock_uuid_empty_set_call(mock_uuid):
 def test_mock_uuid_invalid_uuid_string_raises(mock_uuid):
     """Test that invalid UUID strings raise an error."""
     with pytest.raises(ValueError):
-        mock_uuid.set("not-a-valid-uuid")
+        mock_uuid.uuid4.set("not-a-valid-uuid")
 
 
 def test_mock_uuid_set_can_be_called_multiple_times(mock_uuid):
     """Test that calling set() multiple times replaces previous values."""
-    mock_uuid.set("11111111-1111-4111-8111-111111111111")
+    mock_uuid.uuid4.set("11111111-1111-4111-8111-111111111111")
     assert str(uuid.uuid4()) == "11111111-1111-4111-8111-111111111111"
 
-    mock_uuid.set("22222222-2222-4222-8222-222222222222")
+    mock_uuid.uuid4.set("22222222-2222-4222-8222-222222222222")
     assert str(uuid.uuid4()) == "22222222-2222-4222-8222-222222222222"
 
 
@@ -297,7 +299,7 @@ def test_mock_uuid_set_can_be_called_multiple_times(mock_uuid):
 
 def test_mock_uuid_tracking_with_mocked_uuids(mock_uuid):
     """Test that tracking works correctly with mocked UUIDs."""
-    mock_uuid.set(
+    mock_uuid.uuid4.set(
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222",
     )
@@ -305,20 +307,22 @@ def test_mock_uuid_tracking_with_mocked_uuids(mock_uuid):
     result1 = uuid.uuid4()
     result2 = uuid.uuid4()
 
-    assert mock_uuid.call_count == 2
-    assert mock_uuid.generated_uuids == [result1, result2]
-    assert mock_uuid.last_uuid == result2
-    assert mock_uuid.mocked_count == 2
-    assert all(c.was_mocked for c in mock_uuid.calls)
+    assert mock_uuid.uuid4.call_count == 2
+    assert mock_uuid.uuid4.generated_uuids == [result1, result2]
+    assert mock_uuid.uuid4.last_uuid == result2
+    assert mock_uuid.uuid4.mocked_count == 2
+    assert all(c.was_mocked for c in mock_uuid.uuid4.calls)
 
 
 def test_mock_uuid_tracking_with_real_uuids(mock_uuid):
-    """Test that tracking works when no mock is set (spy mode)."""
+    """Test that tracking works in spy mode (real UUIDs but tracked)."""
+    # Enable spy mode explicitly - this registers the uuid4 mocker
+    mock_uuid.uuid4.spy()
     result = uuid.uuid4()
 
-    assert mock_uuid.call_count == 1
-    assert mock_uuid.last_uuid == result
-    assert mock_uuid.real_count == 1
+    assert mock_uuid.uuid4.call_count == 1
+    assert mock_uuid.uuid4.last_uuid == result
+    assert mock_uuid.uuid4.real_count == 1
 
 
 # --- spy_uuid fixture ---
@@ -352,7 +356,7 @@ def test_spy_uuid_integrates_call_tracking(spy_uuid):
 
 def test_mock_uuid_spy_method_returns_real_uuids(mock_uuid):
     """Test that spy mode returns real UUIDs."""
-    mock_uuid.spy()
+    mock_uuid.uuid4.spy()
 
     result1 = uuid.uuid4()
     result2 = uuid.uuid4()
@@ -363,38 +367,38 @@ def test_mock_uuid_spy_method_returns_real_uuids(mock_uuid):
 
 def test_mock_uuid_spy_mode_still_tracks(mock_uuid):
     """Test that spy mode still tracks calls."""
-    mock_uuid.spy()
+    mock_uuid.uuid4.spy()
 
     result = uuid.uuid4()
 
-    assert mock_uuid.call_count == 1
-    assert mock_uuid.last_uuid == result
+    assert mock_uuid.uuid4.call_count == 1
+    assert mock_uuid.uuid4.last_uuid == result
 
 
 def test_mock_uuid_spy_after_set(mock_uuid):
     """Test switching to spy mode after setting UUIDs."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     uuid.uuid4()  # Returns mocked
 
-    mock_uuid.spy()
+    mock_uuid.uuid4.spy()
     result = uuid.uuid4()  # Returns real
 
     # Real UUID should be different from the mocked one
     assert result != uuid.UUID("12345678-1234-4678-8234-567812345678")
-    assert mock_uuid.call_count == 2
+    assert mock_uuid.uuid4.call_count == 2
 
 
 def test_mock_uuid_spy_mode_tracks_all_calls(mock_uuid):
     """Test that spy mode tracks all calls including before spy()."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     uuid.uuid4()  # Mocked call
 
-    mock_uuid.spy()
+    mock_uuid.uuid4.spy()
     uuid.uuid4()  # Real call
 
     # Both calls should be tracked
-    assert mock_uuid.call_count == 2
-    assert len(mock_uuid.generated_uuids) == 2
+    assert mock_uuid.uuid4.call_count == 2
+    assert len(mock_uuid.uuid4.generated_uuids) == 2
 
 
 # --- UUIDCall tracking integration ---
@@ -417,20 +421,20 @@ def test_uuid_call_captures_caller_info(spy_uuid):
 
 def test_uuid_call_mocked_vs_real_separation(mock_uuid):
     """Test separation of mocked and real (spy mode) calls."""
-    mock_uuid.set("12345678-1234-4678-8234-567812345678")
+    mock_uuid.uuid4.set("12345678-1234-4678-8234-567812345678")
     mocked_result = uuid.uuid4()  # Mocked
 
-    mock_uuid.spy()
+    mock_uuid.uuid4.spy()
     real_result = uuid.uuid4()  # Real
 
     # Check mocked_calls
-    mocked = mock_uuid.mocked_calls
+    mocked = mock_uuid.uuid4.mocked_calls
     assert len(mocked) == 1
     assert mocked[0].uuid == mocked_result
     assert mocked[0].was_mocked is True
 
     # Check real_calls
-    real = mock_uuid.real_calls
+    real = mock_uuid.uuid4.real_calls
     assert len(real) == 1
     assert real[0].uuid == real_result
     assert real[0].was_mocked is False

--- a/tests/unit/test_generators.py
+++ b/tests/unit/test_generators.py
@@ -9,6 +9,10 @@ import pytest
 
 from pytest_uuid.generators import (
     ExhaustionBehavior,
+    RandomUUID1Generator,
+    RandomUUID6Generator,
+    RandomUUID7Generator,
+    RandomUUID8Generator,
     RandomUUIDGenerator,
     SeededUUID1Generator,
     SeededUUID6Generator,
@@ -623,3 +627,312 @@ class TestGetSeededGenerator:
         gen2 = get_seeded_generator("uuid4", 42)
 
         assert gen1() == gen2()
+
+
+# =============================================================================
+# RandomUUID*Generator classes (delegate to real uuid functions)
+# =============================================================================
+
+
+class TestRandomUUID1Generator:
+    """Tests for RandomUUID1Generator."""
+
+    def test_produces_valid_uuid_v1(self):
+        """Test that generated UUIDs are valid v1 UUIDs."""
+        gen = RandomUUID1Generator()
+        result = gen()
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 1
+        assert result.variant == uuid.RFC_4122
+
+    def test_each_call_returns_different_uuid(self):
+        """Test that each call returns a different UUID."""
+        gen = RandomUUID1Generator()
+
+        results = [gen() for _ in range(10)]
+        assert len(set(results)) == 10
+
+    def test_fixed_node_is_preserved(self):
+        """Test that fixed node value is used."""
+        fixed_node = 0x123456789ABC
+        gen = RandomUUID1Generator(node=fixed_node)
+
+        result = gen()
+        assert result.node == fixed_node
+
+    def test_fixed_clock_seq_is_preserved(self):
+        """Test that fixed clock_seq value is used."""
+        fixed_clock_seq = 0x1234
+        gen = RandomUUID1Generator(clock_seq=fixed_clock_seq)
+
+        result = gen()
+        assert result.clock_seq == fixed_clock_seq
+
+    def test_reset_does_nothing(self):
+        """Test that reset doesn't affect the generator."""
+        gen = RandomUUID1Generator()
+
+        gen()
+        gen.reset()  # Should not raise
+        result = gen()
+        assert isinstance(result, uuid.UUID)
+
+
+class TestRandomUUID6Generator:
+    """Tests for RandomUUID6Generator."""
+
+    def test_produces_valid_uuid_v6(self):
+        """Test that generated UUIDs are valid v6 UUIDs."""
+        gen = RandomUUID6Generator()
+        result = gen()
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 6
+        assert result.variant == uuid.RFC_4122
+
+    def test_each_call_returns_different_uuid(self):
+        """Test that each call returns a different UUID."""
+        gen = RandomUUID6Generator()
+
+        results = [gen() for _ in range(10)]
+        assert len(set(results)) == 10
+
+    def test_fixed_node_is_preserved(self):
+        """Test that fixed node value is used."""
+        fixed_node = 0x123456789ABC
+        gen = RandomUUID6Generator(node=fixed_node)
+
+        result = gen()
+        assert result.node == fixed_node
+
+    def test_fixed_clock_seq_is_preserved(self):
+        """Test that fixed clock_seq value is used."""
+        fixed_clock_seq = 0x1234
+        gen = RandomUUID6Generator(clock_seq=fixed_clock_seq)
+
+        result = gen()
+        assert result.clock_seq == fixed_clock_seq
+
+    def test_reset_does_nothing(self):
+        """Test that reset doesn't affect the generator."""
+        gen = RandomUUID6Generator()
+
+        gen()
+        gen.reset()  # Should not raise
+        result = gen()
+        assert isinstance(result, uuid.UUID)
+
+
+class TestRandomUUID7Generator:
+    """Tests for RandomUUID7Generator."""
+
+    def test_produces_valid_uuid_v7(self):
+        """Test that generated UUIDs are valid v7 UUIDs."""
+        gen = RandomUUID7Generator()
+        result = gen()
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 7
+        assert result.variant == uuid.RFC_4122
+
+    def test_each_call_returns_different_uuid(self):
+        """Test that each call returns a different UUID."""
+        gen = RandomUUID7Generator()
+
+        results = [gen() for _ in range(10)]
+        assert len(set(results)) == 10
+
+    def test_reset_does_nothing(self):
+        """Test that reset doesn't affect the generator."""
+        gen = RandomUUID7Generator()
+
+        gen()
+        gen.reset()  # Should not raise
+        result = gen()
+        assert isinstance(result, uuid.UUID)
+
+
+class TestRandomUUID8Generator:
+    """Tests for RandomUUID8Generator."""
+
+    def test_produces_valid_uuid_v8(self):
+        """Test that generated UUIDs are valid v8 UUIDs."""
+        gen = RandomUUID8Generator()
+        result = gen()
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 8
+        assert result.variant == uuid.RFC_4122
+
+    def test_each_call_returns_different_uuid(self):
+        """Test that each call returns a different UUID."""
+        gen = RandomUUID8Generator()
+
+        results = [gen() for _ in range(10)]
+        assert len(set(results)) == 10
+
+    def test_reset_does_nothing(self):
+        """Test that reset doesn't affect the generator."""
+        gen = RandomUUID8Generator()
+
+        gen()
+        gen.reset()  # Should not raise
+        result = gen()
+        assert isinstance(result, uuid.UUID)
+
+
+# =============================================================================
+# Additional SeededUUID6Generator and SeededUUID7Generator tests
+# =============================================================================
+
+
+class TestSeededUUID6GeneratorExtended:
+    """Extended tests for SeededUUID6Generator."""
+
+    def test_reset_restarts_sequence(self):
+        """Test that reset restarts the sequence."""
+        gen = SeededUUID6Generator(42)
+
+        first = gen()
+        gen()  # Skip one
+        gen.reset()
+
+        assert gen() == first
+
+    def test_seed_property_with_integer(self):
+        """Test that seed property returns the integer seed."""
+        gen = SeededUUID6Generator(42)
+        assert gen.seed == 42
+
+    def test_seed_property_with_random_instance(self):
+        """Test that seed property returns None when using Random instance."""
+        rng = random.Random(42)
+        gen = SeededUUID6Generator(rng)
+        assert gen.seed is None
+
+    def test_reset_with_random_instance_does_nothing(self):
+        """Test that reset does nothing when using Random instance."""
+        rng = random.Random(42)
+        gen = SeededUUID6Generator(rng)
+
+        first = gen()
+        gen.reset()  # Should do nothing
+
+        # The next call continues the sequence
+        assert gen() != first
+
+    def test_fixed_node_is_used(self):
+        """Test that fixed node is used in generation."""
+        fixed_node = 0x123456789ABC
+        gen = SeededUUID6Generator(42, node=fixed_node)
+
+        result = gen()
+        assert result.node == fixed_node
+
+    def test_fixed_clock_seq_is_used(self):
+        """Test that fixed clock_seq is used in generation."""
+        fixed_clock_seq = 0x1234
+        gen = SeededUUID6Generator(42, clock_seq=fixed_clock_seq)
+
+        result = gen()
+        assert result.clock_seq == fixed_clock_seq
+
+
+class TestSeededUUID7GeneratorExtended:
+    """Extended tests for SeededUUID7Generator."""
+
+    def test_reset_restarts_sequence(self):
+        """Test that reset restarts the sequence."""
+        gen = SeededUUID7Generator(42)
+
+        first = gen()
+        gen()  # Skip one
+        gen.reset()
+
+        assert gen() == first
+
+    def test_seed_property_with_integer(self):
+        """Test that seed property returns the integer seed."""
+        gen = SeededUUID7Generator(42)
+        assert gen.seed == 42
+
+    def test_seed_property_with_random_instance(self):
+        """Test that seed property returns None when using Random instance."""
+        rng = random.Random(42)
+        gen = SeededUUID7Generator(rng)
+        assert gen.seed is None
+
+    def test_reset_with_random_instance_does_nothing(self):
+        """Test that reset does nothing when using Random instance."""
+        rng = random.Random(42)
+        gen = SeededUUID7Generator(rng)
+
+        first = gen()
+        gen.reset()  # Should do nothing
+
+        # The next call continues the sequence
+        assert gen() != first
+
+
+class TestSeededUUID8GeneratorExtended:
+    """Extended tests for SeededUUID8Generator."""
+
+    def test_reset_restarts_sequence(self):
+        """Test that reset restarts the sequence."""
+        gen = SeededUUID8Generator(42)
+
+        first = gen()
+        gen()  # Skip one
+        gen.reset()
+
+        assert gen() == first
+
+    def test_seed_property_with_integer(self):
+        """Test that seed property returns the integer seed."""
+        gen = SeededUUID8Generator(42)
+        assert gen.seed == 42
+
+    def test_seed_property_with_random_instance(self):
+        """Test that seed property returns None when using Random instance."""
+        rng = random.Random(42)
+        gen = SeededUUID8Generator(rng)
+        assert gen.seed is None
+
+
+# =============================================================================
+# Additional generate_uuid6_from_random tests
+# =============================================================================
+
+
+class TestGenerateUUID6FromRandomExtended:
+    """Extended tests for generate_uuid6_from_random function."""
+
+    def test_fixed_node_is_preserved(self):
+        """Test that fixed node value is used."""
+        rng = random.Random(42)
+        fixed_node = 0x123456789ABC
+
+        result = generate_uuid6_from_random(rng, node=fixed_node)
+        assert result.node == fixed_node
+
+    def test_fixed_clock_seq_is_preserved(self):
+        """Test that fixed clock_seq value is used."""
+        rng = random.Random(42)
+        fixed_clock_seq = 0x1234
+
+        result = generate_uuid6_from_random(rng, clock_seq=fixed_clock_seq)
+        assert result.clock_seq == fixed_clock_seq
+
+    def test_fixed_node_and_clock_seq_together(self):
+        """Test that both fixed node and clock_seq work together."""
+        rng = random.Random(42)
+        fixed_node = 0x123456789ABC
+        fixed_clock_seq = 0x1234
+
+        result = generate_uuid6_from_random(
+            rng, node=fixed_node, clock_seq=fixed_clock_seq
+        )
+        assert result.node == fixed_node
+        assert result.clock_seq == fixed_clock_seq
+        assert result.version == 6

--- a/tests/unit/test_generators.py
+++ b/tests/unit/test_generators.py
@@ -10,11 +10,20 @@ import pytest
 from pytest_uuid.generators import (
     ExhaustionBehavior,
     RandomUUIDGenerator,
+    SeededUUID1Generator,
+    SeededUUID6Generator,
+    SeededUUID7Generator,
+    SeededUUID8Generator,
     SeededUUIDGenerator,
     SequenceUUIDGenerator,
     StaticUUIDGenerator,
     UUIDsExhaustedError,
+    generate_uuid1_from_random,
+    generate_uuid6_from_random,
+    generate_uuid7_from_random,
+    generate_uuid8_from_random,
     generate_uuid_from_random,
+    get_seeded_generator,
     parse_uuid,
     parse_uuids,
 )
@@ -353,3 +362,264 @@ def test_parse_uuids_empty_sequence():
     """Test parsing an empty sequence."""
     result = parse_uuids([])
     assert result == []
+
+
+# =============================================================================
+# Version-specific UUID generation functions
+# =============================================================================
+
+
+class TestGenerateUUID1FromRandom:
+    """Tests for generate_uuid1_from_random function."""
+
+    def test_produces_valid_uuid_v1(self):
+        """Test that generated UUIDs have correct version."""
+        rng = random.Random(42)
+        result = generate_uuid1_from_random(rng)
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 1
+        assert result.variant == uuid.RFC_4122
+
+    def test_seed_reproducibility(self):
+        """Test that same seed produces same UUID."""
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+
+        uuid1 = generate_uuid1_from_random(rng1)
+        uuid2 = generate_uuid1_from_random(rng2)
+
+        assert uuid1 == uuid2
+
+    def test_fixed_node_is_preserved(self):
+        """Test that fixed node value is used."""
+        rng = random.Random(42)
+        fixed_node = 0x123456789ABC
+
+        result = generate_uuid1_from_random(rng, node=fixed_node)
+        assert result.node == fixed_node
+
+    def test_fixed_clock_seq_is_preserved(self):
+        """Test that fixed clock_seq value is used."""
+        rng = random.Random(42)
+        fixed_clock_seq = 0x1234  # 14-bit value
+
+        result = generate_uuid1_from_random(rng, clock_seq=fixed_clock_seq)
+        # Extract clock_seq from UUID (bits 62-76)
+        clock_seq_extracted = result.clock_seq
+        assert clock_seq_extracted == fixed_clock_seq
+
+
+class TestGenerateUUID6FromRandom:
+    """Tests for generate_uuid6_from_random function."""
+
+    def test_produces_valid_uuid_v6(self):
+        """Test that generated UUIDs have correct version."""
+        rng = random.Random(42)
+        result = generate_uuid6_from_random(rng)
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 6
+        assert result.variant == uuid.RFC_4122
+
+    def test_seed_reproducibility(self):
+        """Test that same seed produces same UUID."""
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+
+        uuid1 = generate_uuid6_from_random(rng1)
+        uuid2 = generate_uuid6_from_random(rng2)
+
+        assert uuid1 == uuid2
+
+
+class TestGenerateUUID7FromRandom:
+    """Tests for generate_uuid7_from_random function."""
+
+    def test_produces_valid_uuid_v7(self):
+        """Test that generated UUIDs have correct version."""
+        rng = random.Random(42)
+        result = generate_uuid7_from_random(rng)
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 7
+        assert result.variant == uuid.RFC_4122
+
+    def test_seed_reproducibility(self):
+        """Test that same seed produces same UUID."""
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+
+        uuid1 = generate_uuid7_from_random(rng1)
+        uuid2 = generate_uuid7_from_random(rng2)
+
+        assert uuid1 == uuid2
+
+
+class TestGenerateUUID8FromRandom:
+    """Tests for generate_uuid8_from_random function."""
+
+    def test_produces_valid_uuid_v8(self):
+        """Test that generated UUIDs have correct version."""
+        rng = random.Random(42)
+        result = generate_uuid8_from_random(rng)
+
+        assert isinstance(result, uuid.UUID)
+        assert result.version == 8
+        assert result.variant == uuid.RFC_4122
+
+    def test_seed_reproducibility(self):
+        """Test that same seed produces same UUID."""
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+
+        uuid1 = generate_uuid8_from_random(rng1)
+        uuid2 = generate_uuid8_from_random(rng2)
+
+        assert uuid1 == uuid2
+
+
+# =============================================================================
+# Version-specific seeded generators
+# =============================================================================
+
+
+class TestSeededUUID1Generator:
+    """Tests for SeededUUID1Generator."""
+
+    def test_reproducible_with_integer_seed(self):
+        """Test that integer seed produces reproducible UUIDs."""
+        gen1 = SeededUUID1Generator(42)
+        gen2 = SeededUUID1Generator(42)
+
+        assert gen1() == gen2()
+        assert gen1() == gen2()
+
+    def test_produces_v1_uuids(self):
+        """Test that generated UUIDs are v1."""
+        gen = SeededUUID1Generator(42)
+        result = gen()
+        assert result.version == 1
+
+    def test_reset_restarts_sequence(self):
+        """Test that reset restarts the sequence."""
+        gen = SeededUUID1Generator(42)
+
+        first = gen()
+        gen()  # Skip one
+        gen.reset()
+
+        assert gen() == first
+
+    def test_fixed_node_is_used(self):
+        """Test that fixed node is used in generation."""
+        fixed_node = 0x123456789ABC
+        gen = SeededUUID1Generator(42, node=fixed_node)
+
+        result = gen()
+        assert result.node == fixed_node
+
+    def test_seed_property(self):
+        """Test seed property returns the seed value."""
+        gen = SeededUUID1Generator(42)
+        assert gen.seed == 42
+
+
+class TestSeededUUID6Generator:
+    """Tests for SeededUUID6Generator."""
+
+    def test_reproducible_with_integer_seed(self):
+        """Test that integer seed produces reproducible UUIDs."""
+        gen1 = SeededUUID6Generator(42)
+        gen2 = SeededUUID6Generator(42)
+
+        assert gen1() == gen2()
+
+    def test_produces_v6_uuids(self):
+        """Test that generated UUIDs are v6."""
+        gen = SeededUUID6Generator(42)
+        result = gen()
+        assert result.version == 6
+
+
+class TestSeededUUID7Generator:
+    """Tests for SeededUUID7Generator."""
+
+    def test_reproducible_with_integer_seed(self):
+        """Test that integer seed produces reproducible UUIDs."""
+        gen1 = SeededUUID7Generator(42)
+        gen2 = SeededUUID7Generator(42)
+
+        assert gen1() == gen2()
+
+    def test_produces_v7_uuids(self):
+        """Test that generated UUIDs are v7."""
+        gen = SeededUUID7Generator(42)
+        result = gen()
+        assert result.version == 7
+
+
+class TestSeededUUID8Generator:
+    """Tests for SeededUUID8Generator."""
+
+    def test_reproducible_with_integer_seed(self):
+        """Test that integer seed produces reproducible UUIDs."""
+        gen1 = SeededUUID8Generator(42)
+        gen2 = SeededUUID8Generator(42)
+
+        assert gen1() == gen2()
+
+    def test_produces_v8_uuids(self):
+        """Test that generated UUIDs are v8."""
+        gen = SeededUUID8Generator(42)
+        result = gen()
+        assert result.version == 8
+
+
+# =============================================================================
+# get_seeded_generator factory function
+# =============================================================================
+
+
+class TestGetSeededGenerator:
+    """Tests for get_seeded_generator factory function."""
+
+    @pytest.mark.parametrize(
+        ("version", "expected_type"),
+        [
+            ("uuid1", SeededUUID1Generator),
+            ("uuid4", SeededUUIDGenerator),
+            ("uuid6", SeededUUID6Generator),
+            ("uuid7", SeededUUID7Generator),
+            ("uuid8", SeededUUID8Generator),
+        ],
+    )
+    def test_returns_correct_generator_type(self, version, expected_type):
+        """Test that correct generator type is returned for each version."""
+        gen = get_seeded_generator(version, 42)
+        assert isinstance(gen, expected_type)
+
+    def test_uuid1_accepts_node_and_clock_seq(self):
+        """Test that uuid1 generator accepts node and clock_seq."""
+        gen = get_seeded_generator("uuid1", 42, node=0x123456789ABC, clock_seq=1234)
+        result = gen()
+        assert result.node == 0x123456789ABC
+
+    def test_uuid6_accepts_node_and_clock_seq(self):
+        """Test that uuid6 generator accepts node and clock_seq."""
+        gen = get_seeded_generator("uuid6", 42, node=0x123456789ABC, clock_seq=1234)
+        # Just verify it doesn't raise
+        result = gen()
+        assert result.version == 6
+
+    def test_unknown_version_raises(self):
+        """Test that unknown version raises ValueError."""
+        with pytest.raises(ValueError, match="Seeded generation not supported"):
+            get_seeded_generator("uuid3", 42)
+
+    def test_reproducibility_via_factory(self):
+        """Test that factory produces reproducible generators."""
+        gen1 = get_seeded_generator("uuid4", 42)
+        gen2 = get_seeded_generator("uuid4", 42)
+
+        assert gen1() == gen2()

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -23,6 +23,7 @@ class ConcreteTracker(CallTrackingMixin):
         self._call_count: int = 0
         self._generated_uuids: list[uuid.UUID] = []
         self._calls: list[UUIDCall] = []
+        self._tracking_lock = threading.Lock()
 
 
 # --- CallTrackingMixin ---

--- a/tests/unit/test_uuid1_mocker.py
+++ b/tests/unit/test_uuid1_mocker.py
@@ -96,7 +96,7 @@ class TestUUID1AndUUID4Together:
 
     def test_both_uuid1_and_uuid4_mocked(self, mock_uuid):
         """Test that uuid1 and uuid4 can be mocked independently."""
-        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")
         mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
 
         assert str(uuid.uuid4()) == "44444444-4444-4444-8444-444444444444"
@@ -104,7 +104,7 @@ class TestUUID1AndUUID4Together:
 
     def test_uuid4_mocked_uuid1_real(self, mock_uuid):
         """Test mocking uuid4 while uuid1 returns real values."""
-        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")
         _ = mock_uuid.uuid1  # Initialize but don't mock
 
         uuid4_result = uuid.uuid4()

--- a/tests/unit/test_uuid1_mocker.py
+++ b/tests/unit/test_uuid1_mocker.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
-
 
 class TestUUID1Mocker:
     """Tests for mock_uuid.uuid1 functionality."""

--- a/tests/unit/test_uuid1_mocker.py
+++ b/tests/unit/test_uuid1_mocker.py
@@ -1,0 +1,116 @@
+"""Tests for UUID1 mocking support."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+class TestUUID1Mocker:
+    """Tests for mock_uuid.uuid1 functionality."""
+
+    def test_uuid1_set_returns_static_value(self, mock_uuid):
+        """Test that uuid1.set() returns the specified UUID."""
+        mock_uuid.uuid1.set("12345678-1234-1234-8234-567812345678")
+        result = uuid.uuid1()
+        assert str(result) == "12345678-1234-1234-8234-567812345678"
+
+    def test_uuid1_set_sequence(self, mock_uuid):
+        """Test that uuid1.set() with multiple values cycles through them."""
+        mock_uuid.uuid1.set(
+            "11111111-1111-1111-8111-111111111111",
+            "22222222-2222-2222-8222-222222222222",
+        )
+        assert str(uuid.uuid1()) == "11111111-1111-1111-8111-111111111111"
+        assert str(uuid.uuid1()) == "22222222-2222-2222-8222-222222222222"
+        # Cycles back
+        assert str(uuid.uuid1()) == "11111111-1111-1111-8111-111111111111"
+
+    def test_uuid1_call_tracking(self, mock_uuid):
+        """Test that uuid1 calls are tracked."""
+        mock_uuid.uuid1.set("12345678-1234-1234-8234-567812345678")
+        uuid.uuid1()
+        uuid.uuid1()
+
+        assert mock_uuid.uuid1.call_count == 2
+        assert len(mock_uuid.uuid1.calls) == 2
+        assert mock_uuid.uuid1.calls[0].was_mocked is True
+        assert mock_uuid.uuid1.calls[0].uuid_version == 1
+
+    def test_uuid1_real_passthrough(self, mock_uuid):
+        """Test that uuid1 returns real values when not mocked."""
+        # Access uuid1 mocker but don't set any value
+        _ = mock_uuid.uuid1  # Initialize the mocker
+        result = uuid.uuid1()
+
+        # Should return a real uuid1 (version 1)
+        assert result.version == 1
+        assert mock_uuid.uuid1.call_count == 1
+        assert mock_uuid.uuid1.calls[0].was_mocked is False
+
+    def test_uuid1_seed(self, mock_uuid):
+        """Test that uuid1.set_seed() produces reproducible values."""
+        mock_uuid.uuid1.set_seed(42)
+        first = uuid.uuid1()
+
+        mock_uuid.uuid1.reset()
+        mock_uuid.uuid1.set_seed(42)
+        second = uuid.uuid1()
+
+        assert first == second
+
+    def test_uuid1_set_node(self, mock_uuid):
+        """Test that set_node() affects real uuid1 generation."""
+        test_node = 0x123456789ABC
+        mock_uuid.uuid1.set_node(test_node)
+        result = uuid.uuid1()
+
+        # The node should be the fixed value
+        assert result.node == test_node
+        assert result.version == 1
+
+    def test_uuid1_reset_clears_state(self, mock_uuid):
+        """Test that reset() clears the uuid1 mocker state."""
+        mock_uuid.uuid1.set("12345678-1234-1234-8234-567812345678")
+        mock_uuid.uuid1.set_node(0x123456789ABC)
+        uuid.uuid1()
+
+        mock_uuid.uuid1.reset()
+
+        # After reset, should return real uuid1 values
+        result = uuid.uuid1()
+        assert result.version == 1
+        assert mock_uuid.uuid1.call_count == 1  # Counter was reset
+
+    def test_uuid1_spy_mode(self, mock_uuid):
+        """Test that spy() returns real values but tracks calls."""
+        mock_uuid.uuid1.spy()
+        result = uuid.uuid1()
+
+        assert result.version == 1
+        assert mock_uuid.uuid1.call_count == 1
+        assert mock_uuid.uuid1.calls[0].was_mocked is False
+
+
+class TestUUID1AndUUID4Together:
+    """Tests for using uuid1 and uuid4 mocking together."""
+
+    def test_both_uuid1_and_uuid4_mocked(self, mock_uuid):
+        """Test that uuid1 and uuid4 can be mocked independently."""
+        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
+
+        assert str(uuid.uuid4()) == "44444444-4444-4444-8444-444444444444"
+        assert str(uuid.uuid1()) == "11111111-1111-1111-8111-111111111111"
+
+    def test_uuid4_mocked_uuid1_real(self, mock_uuid):
+        """Test mocking uuid4 while uuid1 returns real values."""
+        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        _ = mock_uuid.uuid1  # Initialize but don't mock
+
+        uuid4_result = uuid.uuid4()
+        uuid1_result = uuid.uuid1()
+
+        assert str(uuid4_result) == "44444444-4444-4444-8444-444444444444"
+        assert uuid1_result.version == 1

--- a/tests/unit/test_uuid3_uuid5_spy.py
+++ b/tests/unit/test_uuid3_uuid5_spy.py
@@ -81,6 +81,21 @@ class TestUUID3Spy:
         assert mock_uuid.uuid3.call_count == 0
         assert len(mock_uuid.uuid3.calls) == 0
 
+    def test_uuid3_calls_from_filters_by_module(self, mock_uuid):
+        """Test that calls_from filters calls by module prefix."""
+        _ = mock_uuid.uuid3
+        # Make some calls from this test module
+        uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        uuid.uuid3(uuid.NAMESPACE_URL, "https://example.com")
+
+        # Filter by this test module
+        test_calls = mock_uuid.uuid3.calls_from("tests.unit.test_uuid3")
+        assert len(test_calls) == 2
+
+        # Filter by non-existent module prefix
+        other_calls = mock_uuid.uuid3.calls_from("nonexistent.module")
+        assert len(other_calls) == 0
+
 
 class TestUUID5Spy:
     """Tests for mock_uuid.uuid5 spy functionality."""

--- a/tests/unit/test_uuid3_uuid5_spy.py
+++ b/tests/unit/test_uuid3_uuid5_spy.py
@@ -1,0 +1,172 @@
+"""Tests for UUID3 and UUID5 spy support."""
+
+from __future__ import annotations
+
+import uuid
+
+
+class TestUUID3Spy:
+    """Tests for mock_uuid.uuid3 spy functionality."""
+
+    def test_uuid3_tracks_calls(self, mock_uuid):
+        """Test that uuid3 calls are tracked."""
+        _ = mock_uuid.uuid3  # Initialize the spy
+        result = uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+
+        assert mock_uuid.uuid3.call_count == 1
+        assert mock_uuid.uuid3.last_uuid == result
+
+    def test_uuid3_captures_namespace_and_name(self, mock_uuid):
+        """Test that namespace and name are captured."""
+        _ = mock_uuid.uuid3
+        uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+
+        call = mock_uuid.uuid3.calls[0]
+        assert call.namespace == uuid.NAMESPACE_DNS
+        assert call.name == "example.com"
+        assert call.uuid_version == 3
+
+    def test_uuid3_returns_real_values(self, mock_uuid):
+        """Test that real uuid3 values are returned."""
+        _ = mock_uuid.uuid3
+        result = uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+
+        # uuid3 is deterministic - same inputs = same output
+        expected = uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        # Note: We can't compare directly since the spy is still active
+        # Just verify it's a valid UUID v3
+        assert result.version == 3
+
+    def test_uuid3_multiple_calls(self, mock_uuid):
+        """Test tracking multiple uuid3 calls."""
+        _ = mock_uuid.uuid3
+        uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        uuid.uuid3(uuid.NAMESPACE_URL, "https://example.com")
+        uuid.uuid3(uuid.NAMESPACE_DNS, "test.org")
+
+        assert mock_uuid.uuid3.call_count == 3
+        assert len(mock_uuid.uuid3.calls) == 3
+        assert mock_uuid.uuid3.calls[0].name == "example.com"
+        assert mock_uuid.uuid3.calls[1].namespace == uuid.NAMESPACE_URL
+        assert mock_uuid.uuid3.calls[2].name == "test.org"
+
+    def test_uuid3_calls_with_namespace_filter(self, mock_uuid):
+        """Test filtering calls by namespace."""
+        _ = mock_uuid.uuid3
+        uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        uuid.uuid3(uuid.NAMESPACE_URL, "https://example.com")
+        uuid.uuid3(uuid.NAMESPACE_DNS, "test.org")
+
+        dns_calls = mock_uuid.uuid3.calls_with_namespace(uuid.NAMESPACE_DNS)
+        assert len(dns_calls) == 2
+        assert all(c.namespace == uuid.NAMESPACE_DNS for c in dns_calls)
+
+    def test_uuid3_calls_with_name_filter(self, mock_uuid):
+        """Test filtering calls by name."""
+        _ = mock_uuid.uuid3
+        uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        uuid.uuid3(uuid.NAMESPACE_URL, "example.com")
+        uuid.uuid3(uuid.NAMESPACE_DNS, "test.org")
+
+        example_calls = mock_uuid.uuid3.calls_with_name("example.com")
+        assert len(example_calls) == 2
+        assert all(c.name == "example.com" for c in example_calls)
+
+    def test_uuid3_reset_clears_tracking(self, mock_uuid):
+        """Test that reset clears tracking data."""
+        _ = mock_uuid.uuid3
+        uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        assert mock_uuid.uuid3.call_count == 1
+
+        mock_uuid.uuid3.reset()
+
+        assert mock_uuid.uuid3.call_count == 0
+        assert len(mock_uuid.uuid3.calls) == 0
+
+
+class TestUUID5Spy:
+    """Tests for mock_uuid.uuid5 spy functionality."""
+
+    def test_uuid5_tracks_calls(self, mock_uuid):
+        """Test that uuid5 calls are tracked."""
+        _ = mock_uuid.uuid5
+        result = uuid.uuid5(uuid.NAMESPACE_DNS, "example.com")
+
+        assert mock_uuid.uuid5.call_count == 1
+        assert mock_uuid.uuid5.last_uuid == result
+
+    def test_uuid5_captures_namespace_and_name(self, mock_uuid):
+        """Test that namespace and name are captured."""
+        _ = mock_uuid.uuid5
+        uuid.uuid5(uuid.NAMESPACE_DNS, "example.com")
+
+        call = mock_uuid.uuid5.calls[0]
+        assert call.namespace == uuid.NAMESPACE_DNS
+        assert call.name == "example.com"
+        assert call.uuid_version == 5
+
+    def test_uuid5_returns_real_values(self, mock_uuid):
+        """Test that real uuid5 values are returned."""
+        _ = mock_uuid.uuid5
+        result = uuid.uuid5(uuid.NAMESPACE_DNS, "example.com")
+
+        # uuid5 is deterministic - verify it's a valid UUID v5
+        assert result.version == 5
+
+    def test_uuid5_multiple_namespaces(self, mock_uuid):
+        """Test tracking with different namespaces."""
+        _ = mock_uuid.uuid5
+        uuid.uuid5(uuid.NAMESPACE_DNS, "example.com")
+        uuid.uuid5(uuid.NAMESPACE_URL, "https://example.com")
+        uuid.uuid5(uuid.NAMESPACE_OID, "1.2.3.4")
+        uuid.uuid5(uuid.NAMESPACE_X500, "cn=test")
+
+        assert mock_uuid.uuid5.call_count == 4
+
+        url_calls = mock_uuid.uuid5.calls_with_namespace(uuid.NAMESPACE_URL)
+        assert len(url_calls) == 1
+        assert url_calls[0].name == "https://example.com"
+
+
+class TestUUID3AndUUID5Together:
+    """Tests for using uuid3 and uuid5 tracking together."""
+
+    def test_uuid3_and_uuid5_tracked_independently(self, mock_uuid):
+        """Test that uuid3 and uuid5 are tracked independently."""
+        _ = mock_uuid.uuid3
+        _ = mock_uuid.uuid5
+
+        uuid.uuid3(uuid.NAMESPACE_DNS, "v3-example.com")
+        uuid.uuid5(uuid.NAMESPACE_DNS, "v5-example.com")
+        uuid.uuid3(uuid.NAMESPACE_DNS, "v3-another.com")
+
+        assert mock_uuid.uuid3.call_count == 2
+        assert mock_uuid.uuid5.call_count == 1
+
+        assert mock_uuid.uuid3.calls[0].name == "v3-example.com"
+        assert mock_uuid.uuid5.calls[0].name == "v5-example.com"
+
+    def test_all_uuid_functions_together(self, mock_uuid):
+        """Test using uuid1, uuid3, uuid4, and uuid5 together."""
+        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
+        _ = mock_uuid.uuid3
+        _ = mock_uuid.uuid5
+
+        # Call all uuid functions
+        result4 = uuid.uuid4()
+        result1 = uuid.uuid1()
+        result3 = uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
+        result5 = uuid.uuid5(uuid.NAMESPACE_DNS, "example.com")
+
+        # Verify mocking/tracking
+        assert str(result4) == "44444444-4444-4444-8444-444444444444"
+        assert str(result1) == "11111111-1111-1111-8111-111111111111"
+        assert result3.version == 3
+        assert result5.version == 5
+
+        # Verify call counts
+        assert mock_uuid.call_count == 1  # uuid4
+        assert mock_uuid.uuid1.call_count == 1
+        assert mock_uuid.uuid3.call_count == 1
+        assert mock_uuid.uuid5.call_count == 1

--- a/tests/unit/test_uuid3_uuid5_spy.py
+++ b/tests/unit/test_uuid3_uuid5_spy.py
@@ -32,8 +32,6 @@ class TestUUID3Spy:
         result = uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
 
         # uuid3 is deterministic - same inputs = same output
-        expected = uuid.uuid3(uuid.NAMESPACE_DNS, "example.com")
-        # Note: We can't compare directly since the spy is still active
         # Just verify it's a valid UUID v3
         assert result.version == 3
 

--- a/tests/unit/test_uuid3_uuid5_spy.py
+++ b/tests/unit/test_uuid3_uuid5_spy.py
@@ -146,7 +146,7 @@ class TestUUID3AndUUID5Together:
 
     def test_all_uuid_functions_together(self, mock_uuid):
         """Test using uuid1, uuid3, uuid4, and uuid5 together."""
-        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")
         mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
         _ = mock_uuid.uuid3
         _ = mock_uuid.uuid5
@@ -164,7 +164,7 @@ class TestUUID3AndUUID5Together:
         assert result5.version == 5
 
         # Verify call counts
-        assert mock_uuid.call_count == 1  # uuid4
+        assert mock_uuid.uuid4.call_count == 1  # uuid4
         assert mock_uuid.uuid1.call_count == 1
         assert mock_uuid.uuid3.call_count == 1
         assert mock_uuid.uuid5.call_count == 1

--- a/tests/unit/test_uuid6_uuid7_uuid8_mocker.py
+++ b/tests/unit/test_uuid6_uuid7_uuid8_mocker.py
@@ -1,0 +1,239 @@
+"""Tests for UUID6, UUID7, and UUID8 mocking support.
+
+These tests require Python 3.14+ or the uuid6 backport package.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pytest_uuid._compat import HAS_UUID6_7_8
+
+# Import uuid6/uuid7/uuid8 from backport if available
+if HAS_UUID6_7_8:
+    from uuid6 import uuid6, uuid7, uuid8
+
+
+import pytest
+
+# Skip all tests if uuid6/7/8 not available
+pytestmark = pytest.mark.skipif(
+    not HAS_UUID6_7_8,
+    reason="uuid6/uuid7/uuid8 requires Python 3.14+ or uuid6 package",
+)
+
+
+class TestUUID6Mocker:
+    """Tests for mock_uuid.uuid6 functionality."""
+
+    def test_uuid6_set_returns_static_value(self, mock_uuid):
+        """Test that uuid6.set() returns the specified UUID."""
+        mock_uuid.uuid6.set("12345678-1234-6234-8234-567812345678")
+        result = uuid6()
+        assert str(result) == "12345678-1234-6234-8234-567812345678"
+
+    def test_uuid6_set_sequence(self, mock_uuid):
+        """Test that uuid6.set() with multiple values cycles through them."""
+        mock_uuid.uuid6.set(
+            "11111111-1111-6111-8111-111111111111",
+            "22222222-2222-6222-8222-222222222222",
+        )
+        assert str(uuid6()) == "11111111-1111-6111-8111-111111111111"
+        assert str(uuid6()) == "22222222-2222-6222-8222-222222222222"
+        # Cycles back
+        assert str(uuid6()) == "11111111-1111-6111-8111-111111111111"
+
+    def test_uuid6_call_tracking(self, mock_uuid):
+        """Test that uuid6 calls are tracked."""
+        mock_uuid.uuid6.set("12345678-1234-6234-8234-567812345678")
+        uuid6()
+        uuid6()
+
+        assert mock_uuid.uuid6.call_count == 2
+        assert len(mock_uuid.uuid6.calls) == 2
+        assert mock_uuid.uuid6.calls[0].was_mocked is True
+        assert mock_uuid.uuid6.calls[0].uuid_version == 6
+
+    def test_uuid6_real_passthrough(self, mock_uuid):
+        """Test that uuid6 returns real values when not mocked."""
+        _ = mock_uuid.uuid6  # Initialize but don't mock
+        result = uuid6()
+
+        # Should return a real uuid6 (version 6)
+        assert result.version == 6
+        assert mock_uuid.uuid6.call_count == 1
+        assert mock_uuid.uuid6.calls[0].was_mocked is False
+
+    def test_uuid6_seed(self, mock_uuid):
+        """Test that uuid6.set_seed() produces reproducible values."""
+        mock_uuid.uuid6.set_seed(42)
+        first = uuid6()
+
+        mock_uuid.uuid6.reset()
+        mock_uuid.uuid6.set_seed(42)
+        second = uuid6()
+
+        assert first == second
+
+    def test_uuid6_set_node(self, mock_uuid):
+        """Test that set_node() affects real uuid6 generation."""
+        test_node = 0x123456789ABC
+        mock_uuid.uuid6.set_node(test_node)
+        result = uuid6()
+
+        assert result.node == test_node
+        assert result.version == 6
+
+
+class TestUUID7Mocker:
+    """Tests for mock_uuid.uuid7 functionality."""
+
+    def test_uuid7_set_returns_static_value(self, mock_uuid):
+        """Test that uuid7.set() returns the specified UUID."""
+        mock_uuid.uuid7.set("12345678-1234-7234-8234-567812345678")
+        result = uuid7()
+        assert str(result) == "12345678-1234-7234-8234-567812345678"
+
+    def test_uuid7_set_sequence(self, mock_uuid):
+        """Test that uuid7.set() with multiple values cycles through them."""
+        mock_uuid.uuid7.set(
+            "11111111-1111-7111-8111-111111111111",
+            "22222222-2222-7222-8222-222222222222",
+        )
+        assert str(uuid7()) == "11111111-1111-7111-8111-111111111111"
+        assert str(uuid7()) == "22222222-2222-7222-8222-222222222222"
+        # Cycles back
+        assert str(uuid7()) == "11111111-1111-7111-8111-111111111111"
+
+    def test_uuid7_call_tracking(self, mock_uuid):
+        """Test that uuid7 calls are tracked."""
+        mock_uuid.uuid7.set("12345678-1234-7234-8234-567812345678")
+        uuid7()
+        uuid7()
+
+        assert mock_uuid.uuid7.call_count == 2
+        assert len(mock_uuid.uuid7.calls) == 2
+        assert mock_uuid.uuid7.calls[0].was_mocked is True
+        assert mock_uuid.uuid7.calls[0].uuid_version == 7
+
+    def test_uuid7_real_passthrough(self, mock_uuid):
+        """Test that uuid7 returns real values when not mocked."""
+        _ = mock_uuid.uuid7  # Initialize but don't mock
+        result = uuid7()
+
+        # Should return a real uuid7 (version 7)
+        assert result.version == 7
+        assert mock_uuid.uuid7.call_count == 1
+        assert mock_uuid.uuid7.calls[0].was_mocked is False
+
+    def test_uuid7_seed(self, mock_uuid):
+        """Test that uuid7.set_seed() produces reproducible values."""
+        mock_uuid.uuid7.set_seed(42)
+        first = uuid7()
+
+        mock_uuid.uuid7.reset()
+        mock_uuid.uuid7.set_seed(42)
+        second = uuid7()
+
+        assert first == second
+
+    def test_uuid7_monotonic_when_not_mocked(self, mock_uuid):
+        """Test that real uuid7 values are monotonic."""
+        _ = mock_uuid.uuid7  # Initialize but don't mock
+
+        # Generate several uuid7 values quickly
+        values = [uuid7() for _ in range(5)]
+
+        # They should be monotonically increasing (uuid7 guarantees this)
+        for i in range(len(values) - 1):
+            # Compare as integers (bytes representation)
+            assert values[i].int < values[i + 1].int
+
+
+class TestUUID8Mocker:
+    """Tests for mock_uuid.uuid8 functionality."""
+
+    def test_uuid8_set_returns_static_value(self, mock_uuid):
+        """Test that uuid8.set() returns the specified UUID."""
+        mock_uuid.uuid8.set("12345678-1234-8234-8234-567812345678")
+        result = uuid8()
+        assert str(result) == "12345678-1234-8234-8234-567812345678"
+
+    def test_uuid8_set_sequence(self, mock_uuid):
+        """Test that uuid8.set() with multiple values cycles through them."""
+        mock_uuid.uuid8.set(
+            "11111111-1111-8111-8111-111111111111",
+            "22222222-2222-8222-8222-222222222222",
+        )
+        assert str(uuid8()) == "11111111-1111-8111-8111-111111111111"
+        assert str(uuid8()) == "22222222-2222-8222-8222-222222222222"
+        # Cycles back
+        assert str(uuid8()) == "11111111-1111-8111-8111-111111111111"
+
+    def test_uuid8_call_tracking(self, mock_uuid):
+        """Test that uuid8 calls are tracked."""
+        mock_uuid.uuid8.set("12345678-1234-8234-8234-567812345678")
+        uuid8()
+        uuid8()
+
+        assert mock_uuid.uuid8.call_count == 2
+        assert len(mock_uuid.uuid8.calls) == 2
+        assert mock_uuid.uuid8.calls[0].was_mocked is True
+        assert mock_uuid.uuid8.calls[0].uuid_version == 8
+
+    def test_uuid8_real_passthrough(self, mock_uuid):
+        """Test that uuid8 returns real values when not mocked."""
+        _ = mock_uuid.uuid8  # Initialize but don't mock
+        result = uuid8()
+
+        # Should return a real uuid8 (version 8)
+        assert result.version == 8
+        assert mock_uuid.uuid8.call_count == 1
+        assert mock_uuid.uuid8.calls[0].was_mocked is False
+
+    def test_uuid8_seed(self, mock_uuid):
+        """Test that uuid8.set_seed() produces reproducible values."""
+        mock_uuid.uuid8.set_seed(42)
+        first = uuid8()
+
+        mock_uuid.uuid8.reset()
+        mock_uuid.uuid8.set_seed(42)
+        second = uuid8()
+
+        assert first == second
+
+
+class TestAllUUIDVersionsTogether:
+    """Tests for using multiple UUID versions together."""
+
+    def test_all_versions_mocked_independently(self, mock_uuid):
+        """Test that all UUID versions can be mocked independently."""
+        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
+        mock_uuid.uuid6.set("66666666-6666-6666-8666-666666666666")
+        mock_uuid.uuid7.set("77777777-7777-7777-8777-777777777777")
+        mock_uuid.uuid8.set("88888888-8888-8888-8888-888888888888")
+
+        assert str(uuid.uuid4()) == "44444444-4444-4444-8444-444444444444"
+        assert str(uuid.uuid1()) == "11111111-1111-1111-8111-111111111111"
+        assert str(uuid6()) == "66666666-6666-6666-8666-666666666666"
+        assert str(uuid7()) == "77777777-7777-7777-8777-777777777777"
+        assert str(uuid8()) == "88888888-8888-8888-8888-888888888888"
+
+    def test_call_counts_independent(self, mock_uuid):
+        """Test that call counts are tracked independently per version."""
+        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
+        mock_uuid.uuid7.set("77777777-7777-7777-8777-777777777777")
+
+        # Call each version different number of times
+        uuid.uuid4()
+        uuid.uuid4()
+        uuid.uuid1()
+        uuid7()
+        uuid7()
+        uuid7()
+
+        assert mock_uuid.call_count == 2
+        assert mock_uuid.uuid1.call_count == 1
+        assert mock_uuid.uuid7.call_count == 3

--- a/tests/unit/test_uuid6_uuid7_uuid8_mocker.py
+++ b/tests/unit/test_uuid6_uuid7_uuid8_mocker.py
@@ -5,13 +5,17 @@ These tests require Python 3.14+ or the uuid6 backport package.
 
 from __future__ import annotations
 
+import sys
 import uuid
 
 from pytest_uuid._compat import HAS_UUID6_7_8
 
-# Import uuid6/uuid7/uuid8 from backport if available
+# Import uuid6/uuid7/uuid8 from stdlib (3.14+) or backport package
 if HAS_UUID6_7_8:
-    from uuid6 import uuid6, uuid7, uuid8
+    if sys.version_info >= (3, 14):
+        from uuid import uuid6, uuid7, uuid8
+    else:
+        from uuid6 import uuid6, uuid7, uuid8
 
 
 import pytest

--- a/tests/unit/test_uuid6_uuid7_uuid8_mocker.py
+++ b/tests/unit/test_uuid6_uuid7_uuid8_mocker.py
@@ -208,7 +208,7 @@ class TestAllUUIDVersionsTogether:
 
     def test_all_versions_mocked_independently(self, mock_uuid):
         """Test that all UUID versions can be mocked independently."""
-        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")
         mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
         mock_uuid.uuid6.set("66666666-6666-6666-8666-666666666666")
         mock_uuid.uuid7.set("77777777-7777-7777-8777-777777777777")
@@ -222,7 +222,7 @@ class TestAllUUIDVersionsTogether:
 
     def test_call_counts_independent(self, mock_uuid):
         """Test that call counts are tracked independently per version."""
-        mock_uuid.set("44444444-4444-4444-8444-444444444444")
+        mock_uuid.uuid4.set("44444444-4444-4444-8444-444444444444")
         mock_uuid.uuid1.set("11111111-1111-1111-8111-111111111111")
         mock_uuid.uuid7.set("77777777-7777-7777-8777-777777777777")
 
@@ -234,6 +234,6 @@ class TestAllUUIDVersionsTogether:
         uuid7()
         uuid7()
 
-        assert mock_uuid.call_count == 2
+        assert mock_uuid.uuid4.call_count == 2
         assert mock_uuid.uuid1.call_count == 1
         assert mock_uuid.uuid7.call_count == 3

--- a/uv.lock
+++ b/uv.lock
@@ -1027,6 +1027,7 @@ dependencies = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "uuid6", marker = "python_full_version < '3.14'" },
 ]
 
 [package.dev-dependencies]
@@ -1050,6 +1051,7 @@ docs = [
 requires-dist = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "uuid6", marker = "python_full_version < '3.14'", specifier = ">=2024.7.10" },
 ]
 
 [package.metadata.requires-dev]
@@ -1338,6 +1340,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1021,7 +1021,7 @@ wheels = [
 
 [[package]]
 name = "pytest-uuid"
-version = "0.7.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Description

Major release adding multi-UUID version support with a redesigned architecture.

### New Features

- **Multi-UUID mocking**: Support for uuid1, uuid4, uuid6, uuid7, uuid8
- **Spy-only tracking**: uuid3 and uuid5 (deterministic hash-based UUIDs don't need mocking)
- **Version-specific freeze functions**: `freeze_uuid4`, `freeze_uuid1`, `freeze_uuid6`, `freeze_uuid7`, `freeze_uuid8`
- **Version-specific pytest markers**: `@pytest.mark.freeze_uuid4`, `@pytest.mark.freeze_uuid1`, etc.
- **Thread-safe call tracking**: All tracking properties use per-instance locks
- **Time-based UUID control**: `node` and `clock_seq` parameters for uuid1/uuid6

### Architecture Changes

- **Proxy-based system**: Replaced import hook with permanent proxy for reliable mocking
- **UUIDMocker container**: Access version-specific mockers via `mock_uuid.uuid4`, `mock_uuid.uuid1`, etc.
- **Python 3.14+ compatibility**: Uses stdlib uuid6/7/8 on 3.14+, uuid6 package on older versions

### Breaking Changes

1. `mock_uuid` fixture now requires explicit version access:
   ```python
   # Before (0.6.x)
   mock_uuid.set("...")
   mock_uuid.call_count
   
   # After (1.0.0)
   mock_uuid.uuid4.set("...")
   mock_uuid.uuid4.call_count
   ```

2. `freeze_uuid()` is now a deprecated alias for `freeze_uuid4()`:
   ```python
   # Before (0.6.x)
   @freeze_uuid("...")
   
   # After (1.0.0)
   @freeze_uuid4("...")
   ```

Closes #6

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation
- [x] Refactoring / code quality

## Testing

- [x] Tests pass locally (`just test`)
- [x] Added/updated tests for changes
- [x] Tested with `just nox` (multi-version)
- [x] Stress tests pass (`just test-stress`)

## Checklist

- [x] Code passes `just lint` and `just format-check`
- [x] Self-reviewed the changes
- [x] Updated documentation
- [x] CHANGELOG updated with migration guide

## Commits Summary

| Area | Changes |
|------|---------|
| Core | Proxy system, multi-UUID mockers, generators |
| API | Version-specific freeze functions and markers |
| Threading | Lock-protected call tracking |
| Compat | Python 3.14+ stdlib uuid6/7/8 support |
| Docs | README, MkDocs site, llms.txt updated |
| Tests | Unit tests, integration tests, stress tests |